### PR TITLE
Use quintiles for raster map previews

### DIFF
--- a/api-scripts/sync-datasets.py
+++ b/api-scripts/sync-datasets.py
@@ -101,9 +101,9 @@ def get_raster_statistics(url):
     })
     stats = statistics_response.json()['b1']
     return {
-        'min': stats['min'],
-        'max': stats['max'],
-        **{ f'percentile_{p}': stats[f'percentile_{p}'] for p in percentiles },
+        'pixel_min_value': stats['min'],
+        'pixel_max_value': stats['max'],
+        **{ f'pixel_percentile_{p}': stats[f'percentile_{p}'] for p in percentiles },
     }
 
 
@@ -161,13 +161,10 @@ def get_raster_layer_metadata(raster_resource):
             'name': raster_resource['name'],
             'type': 'raster',
             'url': url,
-            'pixel_min_value': stats['min'],
-            'pixel_max_value': stats['max'],
-            'pixel_percentile_2': stats['percentile_2'],
-            'pixel_percentile_98': stats['percentile_98'],
             'bounds': info['bounds'],
             'minzoom': info['minzoom'],
             'maxzoom': info['maxzoom'],
+            **stats,
         }
     except Exception as e:
         print('Failed to access GeoTIFF', url)

--- a/api-scripts/sync-datasets.py
+++ b/api-scripts/sync-datasets.py
@@ -94,13 +94,16 @@ def get_raster_info(url):
 
 
 def get_raster_statistics(url):
-    statistics_response = requests.get(TITILER_URL + '/cog/statistics', params={'url': url})
+    percentiles = [2, 20, 40, 60, 80, 98]
+    statistics_response = requests.get(TITILER_URL + '/cog/statistics', params={
+        'url': url,
+        'p': percentiles,
+    })
     stats = statistics_response.json()['b1']
     return {
         'min': stats['min'],
         'max': stats['max'],
-        'percentile_2': stats['percentile_2'],
-        'percentile_98': stats['max'],
+        **{ f'percentile_{p}': stats[f'percentile_{p}'] for p in percentiles },
     }
 
 

--- a/src/ckanext-mappreview/ckanext/mappreview/assets/js/mappreview.js
+++ b/src/ckanext-mappreview/ckanext/mappreview/assets/js/mappreview.js
@@ -30,16 +30,17 @@ ckan.module("mappreview", function ($, _) {
       const endpoint = '/cog/WebMercatorQuad/tilejson.json';
 
       const colors = [
-        [109, 179, 30, 50],
-        [0, 143, 95, 255],
-        [0, 100, 110, 255],
-        [28, 58, 109, 255],
-        [39, 0, 59, 255],
+        [75, 171, 57, 50], // #4BAB39
+        [0, 143, 95, 255], // #008F5F
+        [0, 100, 110, 255], // #00646E
+        [28, 58, 109, 255], // #1C3A6D
+        [32, 40, 93, 255], // #20285D
+        [39, 0, 59, 255], // #27003B
       ];
 
       const colormap = {};
 
-      const percentiles = [2, 20, 40, 60, 80];
+      const percentiles = [2, 20, 40, 60, 80, 98];
       percentiles.forEach((percentile, i) => {
         let colorIndex = this._getColorMapValue(layer.pixel_min_value, layer.pixel_max_value, layer[`pixel_percentile_${percentile}`]);
 
@@ -49,7 +50,6 @@ ckan.module("mappreview", function ($, _) {
 
         colormap[colorIndex] = colors[i];
       });
-      console.log(colormap);
 
       const params = {
         tile_scale: 2,

--- a/src/ckanext-mappreview/ckanext/mappreview/assets/js/mappreview.js
+++ b/src/ckanext-mappreview/ckanext/mappreview/assets/js/mappreview.js
@@ -28,6 +28,8 @@ ckan.module("mappreview", function ($, _) {
         [39, 0, 59, 255],
       ];
 
+      // TODO optionally do quintile
+
       const params = {
         tile_scale: 2,
         url: layer.url,
@@ -36,7 +38,7 @@ ckan.module("mappreview", function ($, _) {
         // rescale: `${layer.pixel_min_value},${layer.pixel_max_value}`,
         rescale: `${layer.pixel_percentile_2},${layer.pixel_percentile_98}`,
         colormap: JSON.stringify({
-          0: colors[0],
+          0: colors[0], // TODO better interpolation
           75: colors[1],
           125: colors[2],
           175: colors[3],
@@ -68,11 +70,6 @@ ckan.module("mappreview", function ($, _) {
         id: layer.name,
         type: 'fill',
         source: layer.name,
-        /*
-        paint: {
-          'raster-opacity': ['interpolate', ['linear'], ['zoom'], 0, 0.75, 12, 1],
-        },
-        */
       };
     },
 


### PR DESCRIPTION
This PR gathers quintiles data from Titiler when the dataset is synced, then uses quintiles linear color ramps when generating raster map previews. This especially improves rendering datasets that are weighted toward one side of the pixel value range.

For example, (before is on the left, with this change on the right):

![image](https://github.com/user-attachments/assets/18959217-754b-4714-a0b8-6dc1a0d57ee5)

NB: Due to changes in the map preview metadata, `sync-datasets` will need to be run after merging this to ensure map previews have the quintiles available.