### PR TITLE
Add extras fields to package form to avoid losing them

### DIFF
--- a/src/ckanext-natcap/ckanext/natcap/templates/scheming/package/snippets/package_form.html
+++ b/src/ckanext-natcap/ckanext/natcap/templates/scheming/package/snippets/package_form.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block metadata_fields %}
+  {% block package_metadata_fields_custom %}
+    {% block custom_fields %}
+      {% snippet 'snippets/custom_form_fields.html', extras=data.extras, errors=errors, limit=3 %}
+    {% endblock %}
+  {% endblock %}
+{% endblock %}


### PR DESCRIPTION
This PR adds extras fields to the package edit form to avoid losing them, as suggested in this [issue comment](https://github.com/ckan/ckanext-scheming/issues/14#issuecomment-174570256).