### PR TITLE
Add vector map previews

### DIFF
--- a/api-scripts/sync-datasets.py
+++ b/api-scripts/sync-datasets.py
@@ -178,43 +178,47 @@ def get_raster_layers_metadata(raster_resources):
 
 
 def get_vector_layer_metadata(vector_resource):
-    url = vector_resource['url']
-    # TODO vectors have separate ymls we should load
-
-    # Does this GeoJSON exist?
-    head_request = requests.head(url)
-    if head_request.status_code != 200:
-        print('Failed to access', url)
-        print('Status code:', head_request.status_code)
-        return None
-
     vector_type = None
     feature_count = None
+    bounds = [-180, -90, 180, 90]
 
-    with urllib.request.urlopen(url) as req:
-        data = json.load(req)
-
-        features = data['features']
-        feature_count = len(features)
-        vector_type = features[0]['geometry']['type']
-
-    # If it exists, get all the info about it
+    # Confirm data exists at url, get some information about it
+    url = vector_resource['url']
     try:
-        # TODO get bounds
-        bounds = [-180, -90, 180, 90]
+        with urllib.request.urlopen(url) as req:
+            data = json.load(req)
 
-        return {
-            'name': vector_resource['name'],
-            'type': 'vector',
-            'url': url,
-            'bounds': bounds,
-            'vector_type': vector_type,
-            'feature_count': feature_count,
-        }
+            features = data['features']
+            feature_count = len(features)
+            vector_type = features[0]['geometry']['type']
     except Exception as e:
-        print('Failed to access', url)
-        print('Status code:', head_request.status_code)
+        print('Failed to access vector dataset', url)
         return None
+
+    # Get bounds from metadata
+    metadata_url = vector_resource['metadata_url']
+    try:
+        with urllib.request.urlopen(metadata_url) as req:
+            yaml_data = yaml.safe_load(req.read())
+            bounding_box = yaml_data['spatial']['bounding_box']
+            bounds = [
+                bounding_box['xmin'],
+                bounding_box['ymin'],
+                bounding_box['xmax'],
+                bounding_box['ymax'],
+            ]
+    except Exception as e:
+        print('Failed to access vector metadata', metadata_url)
+        return None
+
+    return {
+        'name': vector_resource['name'],
+        'type': 'vector',
+        'url': url,
+        'bounds': bounds,
+        'vector_type': vector_type,
+        'feature_count': feature_count,
+    }
 
 
 def get_vector_layers_metadata(vector_resources):
@@ -234,15 +238,20 @@ def get_mappreview_metadata(dataset, zip_sources):
         for shp_source in shp_sources:
             path = shp_source.replace('\\', '/')
             path_start = path.split('/')[0]
-            path_end = '/'.join(path.split('/')[1:]).replace('.shp', '.geojson')
+            path_end = '/'.join(path.split('/')[1:])
 
             base = '/'.join(zip_resource['url'].split('/')[0:-1])
             base = base.replace('https://storage.cloud.google.com/', 'https://storage.googleapis.com/')
-            url = f'{base}/{path_start}/geojsons/{path_end}'
+            geojson_path_end = path_end.replace('.shp', '.geojson')
+            url = f'{base}/{path_start}/geojsons/{geojson_path_end}'
             name = path.split('/')[-1]
+
+            metadata_path_end = path_end.replace('.shp', '.shp.yml')
+            metadata_url = f'{base}/{path_start}/{metadata_path_end}'
 
             vector_resources.append({
                 'name': name,
+                'metadata_url': metadata_url,
                 'url': url,
             })
 

--- a/api-scripts/sync-datasets.py
+++ b/api-scripts/sync-datasets.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import urllib.request
 import json
 import os
 import requests
@@ -178,6 +179,7 @@ def get_raster_layers_metadata(raster_resources):
 
 def get_vector_layer_metadata(vector_resource):
     url = vector_resource['url']
+    # TODO vectors have separate ymls we should load
 
     # Does this GeoJSON exist?
     head_request = requests.head(url)
@@ -185,6 +187,16 @@ def get_vector_layer_metadata(vector_resource):
         print('Failed to access', url)
         print('Status code:', head_request.status_code)
         return None
+
+    vector_type = None
+    feature_count = None
+
+    with urllib.request.urlopen(url) as req:
+        data = json.load(req)
+
+        features = data['features']
+        feature_count = len(features)
+        vector_type = features[0]['geometry']['type']
 
     # If it exists, get all the info about it
     try:
@@ -196,6 +208,8 @@ def get_vector_layer_metadata(vector_resource):
             'type': 'vector',
             'url': url,
             'bounds': bounds,
+            'vector_type': vector_type,
+            'feature_count': feature_count,
         }
     except Exception as e:
         print('Failed to access', url)

--- a/src/ckanext-mappreview/ckanext/mappreview/assets/css/mappreview.css
+++ b/src/ckanext-mappreview/ckanext/mappreview/assets/css/mappreview.css
@@ -6,25 +6,77 @@
 .mappreview .mappreview-mapboxgl-popup .mapboxgl-popup-content {
   max-height: 200px;
   overflow-y: auto;
+  border-radius: 6px;
+  box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.10);
 }
 
 .mappreview .mapboxgl-popup-close-button {
   font-size: 2em;
+  color: var(--color-dark-gray);
+  top: 0.25rem;
+  right: 0.25rem;
 }
 
 .mappreview .mappreview-mapboxgl-popup h3 {
   font-size: 1.25em;
-  color: var(--color-purple);
+  color: var(--color-dark-plum);
   margin-right: 2rem;
 }
 
-.mappreview .popup-row {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 1.5rem;
+.mappreview .popup-grid {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 0.25rem;
 }
 
 .mappreview .popup-key {
   font-weight: bold;
+}
+
+.mappreview .mapboxgl-legend-list {
+  font-family: var(--bs-font-sans-serif);
+  border-radius: 6px;
+  padding: 0.5rem;
+  padding-right: 2rem;
+}
+
+.mappreview .mapboxgl-ctrl-group .mapboxgl-legend-list button {
+  font-size: 0;
+  color: transparent;
+}
+
+.mappreview .mapboxgl-legend-close-button:after {
+  content: '×';
+  color: var(--color-dark-gray);
+  font-size: 1.25rem;
+  line-height: 1.25rem;
+}
+
+.mappreview .mapboxgl-legend-list br {
+  display: none;
+}
+
+.mappreview .mapboxgl-legend-list label {
+  font-weight: 600;
+}
+
+.mappreview .mapboxgl-legend-list label:after {
+  content: '';
+}
+
+.mappreview .mapboxgl-legend-list input[type="checkbox"] {
+  vertical-align: middle;
+}
+
+.mappreview .mapboxgl-legend-title-label {
+  display: none;
+}
+
+.mappreview .mapboxgl-legend-list {
+  overflow-y: auto;
+}
+
+.mappreview .mapboxgl-legend-onlyRendered-checkbox,
+.mappreview .mapboxgl-legend-onlyRendered-label {
+  display: none;
 }


### PR DESCRIPTION
This PR adds (/improves) vector map previews:
 * adds more context in the `sync-datasets` script
 * styles vector layers in mappreview
 * styles the legend
 * adds popups for vector layers

![image](https://github.com/user-attachments/assets/e8e97c25-af18-432c-b944-710128c3c341)
