### PR TITLE
Remove unused templates dir

### DIFF
--- a/src/ckanext-zipexpand/ckanext/zipexpand/templates/base.html
+++ b/src/ckanext-zipexpand/ckanext/zipexpand/templates/base.html
@@ -1,6 +1,0 @@
-{% ckan_extends %}
-
-{% block styles %}
-  {{ super() }}
-  {% asset 'zipexpand/zipexpand-css' %}
-{% endblock %}


### PR DESCRIPTION
This PR removes unused templates and should avoid the following exception:

`Trying to include unknown asset: zipexpand/zipexpand-css`