### PR TITLE
Avoid parsing None as json

### DIFF
--- a/src/ckanext-natcap/ckanext/natcap/templates/package/snippets/additional_info.html
+++ b/src/ckanext-natcap/ckanext/natcap/templates/package/snippets/additional_info.html
@@ -55,7 +55,7 @@
 
         {% set placenames_str = h.get_pkg_dict_extra(pkg_dict, 'placenames') %}
         {% if placenames_str %}
-          {% set placenames = h.natcap_parse_json(placenames_str) %}
+          {% set placenames = h.natcap_parse_json(placenames_str) if placenames_str else [] %}
           <tr>
             <th scope="row" class="dataset-label" property="rdfs:label">{{ _('Places') }}</th>
             <td class="dataset-details" property="rdf:value">

--- a/src/ckanext-natcap/ckanext/natcap/templates/snippets/package_item.html
+++ b/src/ckanext-natcap/ckanext/natcap/templates/snippets/package_item.html
@@ -33,7 +33,9 @@
                   {% block resources_outer %}
                     <ul class="dataset-resources list-unstyled">
                       {% block resources_inner %}
-                        {% for resource in h.natcap_parse_json(h.get_pkg_dict_extra(package, 'sources_res_formats')) %}
+                        {% set formats_str = h.get_pkg_dict_extra(package, 'sources_res_formats') %}
+                        {% set formats = h.natcap_parse_json(formats_str) if formats_str else [] %}
+                        {% for resource in formats %}
                         <li>
                           {% snippet 'package/snippets/source_type_badge.html', ext=h.natcap_get_resource_type_icon_slug(resource) %}
                         </li>


### PR DESCRIPTION
This PR adds some checks before parsing JSON in the plugin to avoid unhelpful log messages.