### PR TITLE
Get full resource URL in plugin

### DIFF
--- a/src/ckanext-natcap/ckanext/natcap/plugin.py
+++ b/src/ckanext-natcap/ckanext/natcap/plugin.py
@@ -263,5 +263,6 @@ class NatcapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
 
     def after_dataset_update(self, context, package):
-        resources = [res.as_dict(core_columns_only=False) for res in context['package'].resources]
+        resource_show = toolkit.get_action('resource_show')
+        resources = [resource_show(context, { 'id': r.id }) for r in context['package'].resources]
         toolkit.enqueue_job(update_dataset, [context['user'], package, resources])

--- a/src/ckanext-natcap/ckanext/natcap/update_dataset.py
+++ b/src/ckanext-natcap/ckanext/natcap/update_dataset.py
@@ -14,7 +14,7 @@ TITILER_URL = os.environ.get('TITILER_URL',
                              'https://titiler-897938321824.us-west1.run.app')
 
 
-def get_dataset_metadata(user: str, resources: list[dict]) -> dict:
+def get_dataset_metadata(resources: list[dict]) -> dict:
     """
     Load the dataset metadata from the dataset's resources.
     """
@@ -23,10 +23,6 @@ def get_dataset_metadata(user: str, resources: list[dict]) -> dict:
 
     for resource in resources:
         if resource['description'] == 'Geometamaker YML':
-            # get the resource from the API to make sure the resource download
-            # URL is fully-qualified.
-            resource = toolkit.get_action('resource_show')(
-                {'user': user}, {'id': resource['id']})
             with urllib.request.urlopen(resource['url']) as response:
                 text = response.read()
                 return yaml.safe_load(text)
@@ -365,7 +361,7 @@ def update_dataset(user, dataset, resources):
         LOGGER.info(f"Skipping update of dataset {dataset['id']}, was updated recently")
         return
 
-    metadata = get_dataset_metadata(user, resources)
+    metadata = get_dataset_metadata(resources)
 
     if not metadata:
         LOGGER.info(f"Skipping update of dataset {dataset['id']}, no metadata found")


### PR DESCRIPTION
This PR loads the full resource dict (with fully-qualified URL) in the plugin rather than the worker.