### PR TITLE
check-in script and jsonschema document

### DIFF
--- a/api-scripts/create-jsonschema-for-metadata.py
+++ b/api-scripts/create-jsonschema-for-metadata.py
@@ -1,0 +1,53 @@
+"""Override base geometamaker.models and create jsonschema representations.
+
+The CKAN DataHub has stricter metdata requirements than those imposed
+by the models in geometamaker. Here we subclass those models and
+overwrite some of the fields to impose those strict requirements.
+
+The main difference in these subclasses is that they do not permit
+empty values for the fields defined.
+
+"""
+import json
+
+import geometamaker
+import yaml
+from pydantic import ConfigDict, constr, conlist
+
+
+class HubLicense(geometamaker.models.LicenseSchema):
+
+    title: constr(min_length=1)
+
+
+class HubContact(geometamaker.models.ContactSchema):
+
+    email: constr(min_length=1)
+    individual_name: constr(min_length=1)
+
+
+class HubResource(geometamaker.models.Resource):
+
+    # extra='allow' is important because we are subclassing
+    # models.Resource, but typically validating against something
+    # more specific like a RasterResource, VectorResource, etc.
+    # Those instances are likely to have extra fields.
+    model_config = ConfigDict(
+      validate_assignment=True,
+      extra='allow')
+
+    citation: constr(min_length=1)
+    contact: HubContact
+    description: constr(min_length=1)
+    keywords: conlist(str, min_length=1)
+    license: HubLicense
+    lineage: constr(min_length=1)
+    placenames: conlist(str, min_length=1)
+    title: constr(min_length=1)
+    url: constr(min_length=1)
+
+
+if __name__ == '__main__':
+    hub_schema = HubResource.model_json_schema()
+    with open('jsonschema/datahub_schema.json', 'w') as file:
+        file.write(json.dumps(hub_schema, indent=2))

--- a/api-scripts/jsonschema/datahub_schema.json
+++ b/api-scripts/jsonschema/datahub_schema.json
@@ -1,0 +1,203 @@
+{
+  "$defs": {
+    "HubContact": {
+      "additionalProperties": false,
+      "properties": {
+        "email": {
+          "minLength": 1,
+          "title": "Email",
+          "type": "string"
+        },
+        "organization": {
+          "default": "",
+          "title": "Organization",
+          "type": "string"
+        },
+        "individual_name": {
+          "minLength": 1,
+          "title": "Individual Name",
+          "type": "string"
+        },
+        "position_name": {
+          "default": "",
+          "title": "Position Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "email",
+        "individual_name"
+      ],
+      "title": "HubContact",
+      "type": "object"
+    },
+    "HubLicense": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "default": "",
+          "description": "URL that describes the license.",
+          "title": "Path",
+          "type": "string"
+        },
+        "title": {
+          "minLength": 1,
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title"
+      ],
+      "title": "HubLicense",
+      "type": "object"
+    }
+  },
+  "additionalProperties": true,
+  "properties": {
+    "contact": {
+      "$ref": "#/$defs/HubContact"
+    },
+    "license": {
+      "$ref": "#/$defs/HubLicense"
+    },
+    "geometamaker_version": {
+      "default": "",
+      "title": "Geometamaker Version",
+      "type": "string"
+    },
+    "metadata_path": {
+      "default": "",
+      "title": "Metadata Path",
+      "type": "string"
+    },
+    "bytes": {
+      "default": 0,
+      "description": "File size of the resource in bytes.",
+      "title": "Bytes",
+      "type": "integer"
+    },
+    "encoding": {
+      "default": "",
+      "description": "File encoding of the resource.",
+      "title": "Encoding",
+      "type": "string"
+    },
+    "format": {
+      "default": "",
+      "description": "File format of the resource.",
+      "title": "Format",
+      "type": "string"
+    },
+    "uid": {
+      "default": "",
+      "description": "Unique identifier for the resource.",
+      "title": "Uid",
+      "type": "string"
+    },
+    "path": {
+      "default": "",
+      "description": "Path to the resource being described.",
+      "title": "Path",
+      "type": "string"
+    },
+    "scheme": {
+      "default": "",
+      "description": "File protocol for opening the resource.",
+      "title": "Scheme",
+      "type": "string"
+    },
+    "type": {
+      "default": "",
+      "description": "The type of resource being described.",
+      "title": "Type",
+      "type": "string"
+    },
+    "last_modified": {
+      "default": "",
+      "description": "Last modified time of the file at ``path``.",
+      "title": "Last Modified",
+      "type": "string"
+    },
+    "sources": {
+      "description": "A list of files which comprise the dataset or resource.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Sources",
+      "type": "array"
+    },
+    "citation": {
+      "minLength": 1,
+      "title": "Citation",
+      "type": "string"
+    },
+    "description": {
+      "minLength": 1,
+      "title": "Description",
+      "type": "string"
+    },
+    "doi": {
+      "default": "",
+      "description": "A digital object identifier for the resource.",
+      "title": "Doi",
+      "type": "string"
+    },
+    "edition": {
+      "default": "",
+      "description": "A string representing the edition, or version, of the resource.",
+      "title": "Edition",
+      "type": "string"
+    },
+    "keywords": {
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Keywords",
+      "type": "array"
+    },
+    "lineage": {
+      "minLength": 1,
+      "title": "Lineage",
+      "type": "string"
+    },
+    "placenames": {
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Placenames",
+      "type": "array"
+    },
+    "purpose": {
+      "default": "",
+      "description": "The author's stated purpose for the resource.",
+      "title": "Purpose",
+      "type": "string"
+    },
+    "title": {
+      "minLength": 1,
+      "title": "Title",
+      "type": "string"
+    },
+    "url": {
+      "minLength": 1,
+      "title": "Url",
+      "type": "string"
+    }
+  },
+  "required": [
+    "contact",
+    "license",
+    "citation",
+    "description",
+    "keywords",
+    "lineage",
+    "placenames",
+    "title",
+    "url"
+  ],
+  "title": "HubResource",
+  "type": "object"
+}


### PR DESCRIPTION
Here's an example of how we can use `geometamaker` models and `jsonschema` to validate metadata documents against a schema that is stricter than the base models defined in `geometamaker`. I'm opening this PR because it's a convenient way to share the example. But it's mostly unsolicited so I'm not expecting you all to merge it.

`create-jsonschema-for-metadata.py` is an example of how to create a JSON schema based on subclasses of `geometamaker.models`, allowing us to override the fields and impose stricter requirements, such as they cannot be empty. Lots more customization is possible here.

`datahub_schema.json` is the resulting JSON schema document, which can be hosted remotely or locally and used to validate metadata documents created by `geometamaker`.

For example, I'm using the `check-jsonschema` CLI (`pip install check-jsonschema`) to validate a yml doc. 
```
(C:\Users\dmf\projects\geometamaker\env-py313) λ check-jsonschema --schemafile https://raw.githubusercontent.com/davemfish/data.naturalcapitalproject.stanford.edu/refs/heads/exp/jsonschema-for-metadata/api-scripts/jsonschema/datahub_schema.json DEM_gura.tif.yml
Schema validation errors were encountered.
  DEM_gura.tif.yml::$.contact.email: '' should be non-empty
  DEM_gura.tif.yml::$.contact.individual_name: '' should be non-empty
  DEM_gura.tif.yml::$.license.title: '' should be non-empty
  DEM_gura.tif.yml::$.citation: '' should be non-empty
  DEM_gura.tif.yml::$.description: '' should be non-empty
  DEM_gura.tif.yml::$.keywords: [] should be non-empty
  DEM_gura.tif.yml::$.lineage: '' should be non-empty
  DEM_gura.tif.yml::$.placenames: [] should be non-empty
  DEM_gura.tif.yml::$.title: '' should be non-empty
```