### PR TITLE
Read URLs from environment variables and support self-signed certs

### DIFF
--- a/api-scripts/create-or-update-dataset.py
+++ b/api-scripts/create-or-update-dataset.py
@@ -43,6 +43,11 @@ URL = os.environ.get(
 
 MODIFIED_APIKEY = os.environ['CKAN_APIKEY']
 
+# Disable SSL verification if we're running on localhost.
+VERIFY=True
+if URL.split('https://')[1].startswith('localhost'):
+    VERIFY=False
+
 RESOURCES_BY_EXTENSION = {
     '.csv': 'CSV Table',
     '.tif.aux.xml': 'GDAL Auxiliary XML',
@@ -305,7 +310,9 @@ def main(gmm_yaml_path, private=False, group=None):
     session = requests.Session()
     session.headers.update({'Authorization': MODIFIED_APIKEY})
 
-    with RemoteCKAN(URL, apikey=MODIFIED_APIKEY) as catalog:
+    session = requests.Session()
+    session.verify = VERIFY
+    with RemoteCKAN(URL, apikey=MODIFIED_APIKEY, session=session) as catalog:
         print('list org natcap', catalog.action.organization_list(id='natcap'))
 
         licenses = catalog.action.license_list()

--- a/api-scripts/sync-data-to-staging.py
+++ b/api-scripts/sync-data-to-staging.py
@@ -7,9 +7,11 @@ import textwrap
 
 import requests
 
-STAGING_URL = 'https://data-staging.naturalcapitalproject.org'
+STAGING_URL = os.environ.get(
+    'CKAN_STAGING_URL', 'https://data-staging.naturalcapitalproject.org')
 STAGING_API = f'{STAGING_URL}/api/3/action'
-PROD_URL = 'https://data.naturalcapitalproject.stanford.edu'
+PROD_URL = os.environ.get(
+    'CKAN_PROD_URL', 'https://data.naturalcapitalproject.stanford.edu')
 PROD_API = f'{PROD_URL}/api/3/action'
 STAGING_API_KEY = os.environ['CKAN_STAGING_APIKEY']
 

--- a/api-scripts/sync-data-to-staging.py
+++ b/api-scripts/sync-data-to-staging.py
@@ -1,3 +1,16 @@
+"""Sync all datasets from prod to a staging CKAN instance.
+
+See api-scripts/create-or-update-dataset.py for the list of dependencies and
+required setup to run this program.
+
+By default, this program will sync datasets from prod
+(https://data.naturalcapitalproject.stanford.edu) over to staging
+(https://data-staging.naturalcapitalproject.org).  If you want to sync to a
+local docker-compose cluster, set environment variables like so:
+
+    $ CKAN_STAGING_URL="https://localhost:8443" CKAN_STAGING_APIKEY="<my api key>" python api-scripts/sync-data-to-staging.py
+"""
+
 import argparse
 import contextlib
 import os
@@ -17,6 +30,11 @@ STAGING_API_KEY = os.environ['CKAN_STAGING_APIKEY']
 
 CUR_DIR = os.path.dirname(__file__)
 
+# Disable SSL verification if we're running on localhost.
+VERIFY=True
+if STAGING_URL.split('https://')[1].startswith('localhost'):
+    VERIFY=False
+
 # list out sources on ckan
 # clean out the sources
 # fetch all resource yaml files
@@ -35,6 +53,7 @@ INVALID_GMM_PACKAGE_MSG = textwrap.dedent(
 @contextlib.contextmanager
 def http_session(api_key=None):
     session = requests.Session()
+    session.verify = VERIFY
     if api_key is not None:
         session.headers.update({'Authorization': api_key})
     yield session


### PR DESCRIPTION
Just a very minor change to read URLs from environment variables if possible.

NOTE: a `natcap` organization is very likely required at this time, which can be created manually until #102 is addressed.