### PR TITLE
Add Contact Info to About Section

### DIFF
--- a/src/ckanext-natcap/ckanext/natcap/templates/footer.html
+++ b/src/ckanext-natcap/ckanext/natcap/templates/footer.html
@@ -5,21 +5,21 @@
 
 {% block footer_content %}
 <div class="row">
-   <div class="col-md-3">
-      <a class="icon-link" href="https://naturalcapitalproject.stanford.edu/">
-         <img src="/img/natcap-logo.png" alt="The Natural Capital Project logo" />
-      </a>
-   </div>
-   <div class="col-md-9">
-      <h2>About</h2>
-      <div>
-         <p>
-            The Natural Capital Project Data Hub provides analysis-ready ecosystem services data as well as data for and from InVEST®, our suite of free, open-source ecosystem service models. With this Data Hub, we intend to make it faster and simpler for anyone to create and use ecosystem services information for a wide range of analyses and decisions.
-         </p>
-         <p>
-         <a href="https://naturalcapitalproject.stanford.edu/">The Natural Capital Project</a>, based at Stanford University, is a partnership between interdisciplinary researchers, professionals, and leaders working to make valuing natural capital easier and more accessible to all. To read more about the Natural Capital Project and InVEST, please visit our <a href="https://naturalcapitalproject.stanford.edu">website</a>.
-         </p>
-      </div>
-   </div>
+  <div class="col-md-3">
+    <a class="icon-link" href="https://naturalcapitalproject.stanford.edu/">
+      <img src="/img/natcap-logo.png" alt="The Natural Capital Project logo" />
+    </a>
+  </div>
+  <div class="col-md-9">
+    <h2>About</h2>
+    <div>
+      <p>
+        The Natural Capital Project Data Hub provides analysis-ready ecosystem services data as well as data for and from InVEST®, our suite of free, open-source ecosystem service models. With this Data Hub, we intend to make it faster and simpler for anyone to create and use ecosystem services information for a wide range of analyses and decisions. <a href="mailto:datahub@naturalcapitalproject.org">Contact us</a> with feedback about the site or suggestions for open access datasets to add.
+      </p>
+      <p>
+        <a href="https://naturalcapitalproject.stanford.edu/">The Natural Capital Project</a>, based at Stanford University, is a partnership between interdisciplinary researchers, professionals, and leaders working to make valuing natural capital easier and more accessible to all. To read more about the Natural Capital Project and InVEST, please visit our <a href="https://naturalcapitalproject.stanford.edu">website</a>.
+      </p>
+    </div>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR adds our contact email to the About section in the site footer. 

I also realized the footer was 3-space indented for some reason, so I've adjusted that to 2 spaces to match our other HTML files. 

Fixes #109 