### PR TITLE
Update depencency list in `create-or-update-dataset.py`

### DIFF
--- a/api-scripts/create-or-update-dataset.py
+++ b/api-scripts/create-or-update-dataset.py
@@ -3,7 +3,7 @@
 If the dataset already exists, then its attributes are updated.
 
 Dependencies:
-    $ mamba install ckanapi pyyaml google-cloud-storage requests gdal
+    $ mamba install ckanapi pyyaml google-cloud-storage requests gdal pygeoprocessing
 
 Note:
     You will need to authenticate with the google cloud api in order to do


### PR DESCRIPTION
When running `create-or-update-dataset.py`, I realized the dependency list included in the docstring at the top of the file was missing `pygeoprocessing`. This PR updates that docstring to reflect the additional dependency! 