### PR TITLE
Throttle bot requests via nginx host configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,7 +82,7 @@ NGINX_SSLPORT=443
 
 # Extensions
 # NOTE: PLUGIN ORDER MATTERS!  BE CAREFUL
-CKAN__PLUGINS="or_facet googleanalytics envvars natcap tracking image_view text_view datatables_view datastore datapusher mappreview spatial_metadata spatial_query stats activity scheming_datasets zipexpand"
+CKAN__PLUGINS="or_facet googleanalytics envvars natcap tracking image_view text_view datatables_view datastore datapusher mappreview spatial_metadata spatial_query stats activity scheming_datasets zipexpand sitemap"
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -36,6 +36,8 @@ RUN pip3 install -e git+https://github.com/ckan/ckanext-googleanalytics.git@$CKA
 ENV CKANEXT_ORFACET_GIT_REV=7a01391186761ff112a76bc7e62dd487330a2371
 RUN pip3 install -e git+https://github.com/DataShades/ckanext-or_facet.git@$CKANEXT_ORFACET_GIT_REV#egg=ckanext-or_facet
 
+RUN pip3 install -e git+https://github.com/datopian/ckanext-sitemap.git#egg=ckanext-sitemap
+
 # NOTE: requires that the build context includes ./src/
 COPY ./src/ckanext-natcap /srv/app/src/ckanext-natcap
 RUN pip3 install -r /srv/app/src/ckanext-natcap/requirements.txt && \

--- a/host-nginx/etc.nginx.ckan-proxy.conf
+++ b/host-nginx/etc.nginx.ckan-proxy.conf
@@ -1,0 +1,15 @@
+proxy_pass https://localhost:8443;
+#uwsgi_pass uwsgi://localhost:8080;
+proxy_set_header Host $host;
+proxy_cache cache;
+proxy_cache_bypass $cookie_auth_tkt;
+proxy_no_cache $cookie_auth_tkt;
+proxy_cache_valid 30m;
+proxy_cache_key $host$scheme$proxy_host$request_uri;
+# In emergency comment out line to force caching
+# proxy_ignore_headers X-Accel-Expires Expires Cache-Control;
+
+# Added 2023-08-28 to try to resolve "upstream prematurely closed connection while reading response header from upstream, for large requests" in logs
+# Suggested by https://stackoverflow.com/a/48858256
+proxy_connect_timeout 10s;
+proxy_read_timeout 15s;

--- a/host-nginx/etc.nginx.nginx.conf
+++ b/host-nginx/etc.nginx.nginx.conf
@@ -1,5 +1,3 @@
-# This is the standard nginx configuration used on our host at /etc/nginx/nginx.conf
-
 user www-data;
 worker_processes auto;
 pid /run/nginx.pid;
@@ -59,6 +57,7 @@ http {
 	##
 	# Virtual Host Configs
 	##
+
 	include /etc/nginx/conf.d/*.conf;
 	include /etc/nginx/sites-enabled/*;
 }
@@ -67,17 +66,17 @@ http {
 #mail {
 #	# See sample authentication script at:
 #	# http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
-#
+# 
 #	# auth_http localhost/auth.php;
 #	# pop3_capabilities "TOP" "USER";
 #	# imap_capabilities "IMAP4rev1" "UIDPLUS";
-#
+# 
 #	server {
 #		listen     localhost:110;
 #		protocol   pop3;
 #		proxy      on;
 #	}
-#
+# 
 #	server {
 #		listen     localhost:143;
 #		protocol   imap;

--- a/host-nginx/etc.nginx.sites-available.ckan
+++ b/host-nginx/etc.nginx.sites-available.ckan
@@ -7,28 +7,18 @@ server {
     server_name data.naturalcapitalproject.stanford.edu;
 
     location / {
-	# NGINX doesn't have an AND syntax, so we have to make do.
-	# See https://stackoverflow.com/a/57898777 for conditionals
-	# See https://stackoverflow.com/a/77952129 for regexp
-	if ($http_user_agent ~* "SemrushBot|Semrush|AhrefsBot|MJ12bot|YandexBot|YandexImages|MegaIndex.ru|BLEXbot|BLEXBot|ZoominfoBot|YaK|VelenPublicWebCrawler|SentiBot|Vagabondo|SEOkicks|SEOkicks-Robot|mtbot/1.1.0i|SeznamBot|DotBot|Cliqzbot|coccocbot|python|Scrap|SiteCheck-sitecrawl|MauiBot|Java|GumGum|Clickagy|AspiegelBot|Yandex|TkBot|CCBot|Qwantify|MBCrawler|serpstatbot|AwarioSmartBot|Semantici|ScholarBot|proximic|MojeekBot|GrapeshotCrawler|IAScrawler|linkdexbot|contxbot|PlurkBot|PaperLiBot|BomboraBot|Leikibot|weborama-fetcher|NTENTbot|Screaming Frog SEO Spider|admantx-usaspb|Eyeotabot|VoluumDSP-content-bot|SirdataBot|adbeat_bot|TTD-Content|admantx|Nimbostratus-Bot|Mail.RU_Bot|Quantcastboti|Onespot-ScraperBot|Taboolabot|Baidu|Jobboerse|VoilaBot|Sogou|Jyxobot|Exabot|ZGrab|Proximi|Sosospider|Accoona|aiHitBot|Genieo|BecomeBot|ConveraCrawler|NerdyBot|OutclicksBot|findlinks|JikeSpider|Gigabot|CatchBot|Huaweisymantecspider|Offline Explorer|SiteSnagger|TeleportPro|WebCopier|WebReaper|WebStripper|WebZIP|Xaldon_WebSpider|BackDoorBot|AITCSRoboti|Arachnophilia|BackRub|BlowFishi|perl|CherryPicker|CyberSpyder|EmailCollector|Foobot|GetURL|httplib|HTTrack|LinkScan|Openbot|Snooper|SuperBot|URLSpiderPro|MAZBot|EchoboxBot|SerendeputyBot|LivelapBot|linkfluence.com|TweetmemeBot|LinkisBot|CrowdTanglebot|Bytespider") { 
-		set $isbot 1;
-	}
-	if ($query_string ~ q=) {
-		set $isbot 1$isbot;
-	}
-
 	# Block bot query strings on specific pages only.  We DO want bots to
 	# index/crawl datasets, just not to use the search feature.
 	location = /dataset/ {
-		if ($isbot = 11) {
-			return 403;
-		}
+		include /etc/nginx/throttle-bots.conf;
 		include /etc/nginx/ckan-proxy.conf;
 	}
 	location = /organization/natcap/ {
-		if ($isbot = 11) {
-			return 403;
-		}
+		include /etc/nginx/throttle-bots.conf;
+		include /etc/nginx/ckan-proxy.conf;
+	}
+	location = /organization/48bdf034-675f-4017-970f-738a5b7869ce {
+		include /etc/nginx/throttle-bots.conf;
 		include /etc/nginx/ckan-proxy.conf;
 	}
 

--- a/host-nginx/etc.nginx.sites-available.ckan
+++ b/host-nginx/etc.nginx.sites-available.ckan
@@ -1,5 +1,3 @@
-# This file is located on the host computer at /etc/nginx/sites-available/ckan and contains configuration for forwarding to our docker cluster.
-
 proxy_cache_path /tmp/nginx_cache levels=1:2 keys_zone=cache:30m max_size=250m;
 proxy_temp_path /tmp/nginx_proxy 1 2;
 
@@ -9,38 +7,49 @@ server {
     server_name data.naturalcapitalproject.stanford.edu;
 
     location / {
-        proxy_pass https://localhost:8443;
-        #uwsgi_pass uwsgi://localhost:8080;
-        proxy_set_header Host $host;
-        proxy_cache cache;
-        proxy_cache_bypass $cookie_auth_tkt;
-        proxy_no_cache $cookie_auth_tkt;
-        proxy_cache_valid 30m;
-        proxy_cache_key $host$scheme$proxy_host$request_uri;
-        # In emergency comment out line to force caching
-        # proxy_ignore_headers X-Accel-Expires Expires Cache-Control;
+	# NGINX doesn't have an AND syntax, so we have to make do.
+	# See https://stackoverflow.com/a/57898777 for conditionals
+	# See https://stackoverflow.com/a/77952129 for regexp
+	if ($http_user_agent ~* "SemrushBot|Semrush|AhrefsBot|MJ12bot|YandexBot|YandexImages|MegaIndex.ru|BLEXbot|BLEXBot|ZoominfoBot|YaK|VelenPublicWebCrawler|SentiBot|Vagabondo|SEOkicks|SEOkicks-Robot|mtbot/1.1.0i|SeznamBot|DotBot|Cliqzbot|coccocbot|python|Scrap|SiteCheck-sitecrawl|MauiBot|Java|GumGum|Clickagy|AspiegelBot|Yandex|TkBot|CCBot|Qwantify|MBCrawler|serpstatbot|AwarioSmartBot|Semantici|ScholarBot|proximic|MojeekBot|GrapeshotCrawler|IAScrawler|linkdexbot|contxbot|PlurkBot|PaperLiBot|BomboraBot|Leikibot|weborama-fetcher|NTENTbot|Screaming Frog SEO Spider|admantx-usaspb|Eyeotabot|VoluumDSP-content-bot|SirdataBot|adbeat_bot|TTD-Content|admantx|Nimbostratus-Bot|Mail.RU_Bot|Quantcastboti|Onespot-ScraperBot|Taboolabot|Baidu|Jobboerse|VoilaBot|Sogou|Jyxobot|Exabot|ZGrab|Proximi|Sosospider|Accoona|aiHitBot|Genieo|BecomeBot|ConveraCrawler|NerdyBot|OutclicksBot|findlinks|JikeSpider|Gigabot|CatchBot|Huaweisymantecspider|Offline Explorer|SiteSnagger|TeleportPro|WebCopier|WebReaper|WebStripper|WebZIP|Xaldon_WebSpider|BackDoorBot|AITCSRoboti|Arachnophilia|BackRub|BlowFishi|perl|CherryPicker|CyberSpyder|EmailCollector|Foobot|GetURL|httplib|HTTrack|LinkScan|Openbot|Snooper|SuperBot|URLSpiderPro|MAZBot|EchoboxBot|SerendeputyBot|LivelapBot|linkfluence.com|TweetmemeBot|LinkisBot|CrowdTanglebot|Bytespider") { 
+		set $isbot 1;
+	}
+	if ($query_string ~ q=) {
+		set $isbot 1$isbot;
+	}
 
-	# Added 2023-08-28 to try to resolve "upstream prematurely closed connection while reading response header from upstream, for large requests" in logs
-	# Suggested by https://stackoverflow.com/a/48858256
-	proxy_connect_timeout 10s;
-	proxy_read_timeout 15s;
+	# Block bot query strings on specific pages only.  We DO want bots to
+	# index/crawl datasets, just not to use the search feature.
+	location = /dataset/ {
+		if ($isbot = 11) {
+			return 403;
+		}
+		include /etc/nginx/ckan-proxy.conf;
+	}
+	location = /organization/natcap/ {
+		if ($isbot = 11) {
+			return 403;
+		}
+		include /etc/nginx/ckan-proxy.conf;
+	}
 
+	# Need this here for the homepage and any resources accessible off of the home page.
+	include /etc/nginx/ckan-proxy.conf;
     }
 
-    if ($http_referer ~ ^https?://data.naturalcapitalproject.stanford.edu/apps/layer-clipper/) {
-        rewrite ^ /apps/layer-clipper$uri;
-    }
-    location /apps/layer-clipper/ {
-	proxy_pass http://127.0.0.1:8866/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    #if ($http_referer ~ ^https?://data.naturalcapitalproject.stanford.edu/apps/layer-clipper/) {
+    #    rewrite ^ /apps/layer-clipper$uri;
+    #}
+    #location /apps/layer-clipper/ {
+    #    proxy_pass http://127.0.0.1:8866/;
+    #    proxy_set_header Host $host;
+    #    proxy_set_header X-Real-IP $remote_addr;
+    #    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_read_timeout 86400;
-    }
+    #    proxy_http_version 1.1;
+    #    proxy_set_header Upgrade $http_upgrade;
+    #    proxy_set_header Connection "upgrade";
+    #    proxy_read_timeout 86400;
+    #}
 
 
     listen [::]:443 ssl ipv6only=on; # managed by Certbot

--- a/host-nginx/etc.nginx.throttle-bots.conf
+++ b/host-nginx/etc.nginx.throttle-bots.conf
@@ -1,0 +1,13 @@
+# NGINX doesn't have an AND syntax, so we have to make do.
+# See https://stackoverflow.com/a/57898777 for conditionals
+# See https://stackoverflow.com/a/77952129 for regexp
+if ($http_user_agent ~* "SemrushBot|Semrush|AhrefsBot|MJ12bot|YandexBot|YandexImages|MegaIndex.ru|BLEXbot|BLEXBot|ZoominfoBot|YaK|VelenPublicWebCrawler|SentiBot|Vagabondo|SEOkicks|SEOkicks-Robot|mtbot/1.1.0i|SeznamBot|DotBot|Cliqzbot|coccocbot|python|Scrap|SiteCheck-sitecrawl|MauiBot|Java|GumGum|Clickagy|AspiegelBot|Yandex|TkBot|CCBot|Qwantify|MBCrawler|serpstatbot|AwarioSmartBot|Semantici|ScholarBot|proximic|MojeekBot|GrapeshotCrawler|IAScrawler|linkdexbot|contxbot|PlurkBot|PaperLiBot|BomboraBot|Leikibot|weborama-fetcher|NTENTbot|Screaming Frog SEO Spider|admantx-usaspb|Eyeotabot|VoluumDSP-content-bot|SirdataBot|adbeat_bot|TTD-Content|admantx|Nimbostratus-Bot|Mail.RU_Bot|Quantcastboti|Onespot-ScraperBot|Taboolabot|Baidu|Jobboerse|VoilaBot|Sogou|Jyxobot|Exabot|ZGrab|Proximi|Sosospider|Accoona|aiHitBot|Genieo|BecomeBot|ConveraCrawler|NerdyBot|OutclicksBot|findlinks|JikeSpider|Gigabot|CatchBot|Huaweisymantecspider|Offline Explorer|SiteSnagger|TeleportPro|WebCopier|WebReaper|WebStripper|WebZIP|Xaldon_WebSpider|BackDoorBot|AITCSRoboti|Arachnophilia|BackRub|BlowFishi|perl|CherryPicker|CyberSpyder|EmailCollector|Foobot|GetURL|httplib|HTTrack|LinkScan|Openbot|Snooper|SuperBot|URLSpiderPro|MAZBot|EchoboxBot|SerendeputyBot|LivelapBot|linkfluence.com|TweetmemeBot|LinkisBot|CrowdTanglebot|Bytespider|Googleother|TikTokSpider|AcademicBotRTU|Googlebot") { 
+	set $isbot 1;
+}
+# The $is_args variable is a question mark if there are arguments present.
+if ($query_string) {
+	set $isbot 1$isbot;
+}
+if ($isbot = 11) {
+	return 403;
+}

--- a/src/ckanext-natcap/ckanext/natcap/templates/home/robots.txt
+++ b/src/ckanext-natcap/ckanext/natcap/templates/home/robots.txt
@@ -9,6 +9,8 @@ Disallow /dataset/?*
 
 User-agent: Bytespider
 Disallow /dataset/?*
+
+Sitemap: https://data.naturalcapitalproject.stanford.edu/sitemap.xml
 {%- endblock %}
 
 


### PR DESCRIPTION
The above pretty solidly fixed the Bytespider issue, since the bot wasn't respecting `robots.txt`.  The weakness of this approach is that it still relies on bots using the browser string to identify themselves, which is still a convention and easily broken.

Anyways, it's a step in the right direction and it did help limit traffic when it went into place.

Fixes #108