### PR TITLE
CLI for the create-or-update script

### DIFF
--- a/api-scripts/create-or-update-dataset.py
+++ b/api-scripts/create-or-update-dataset.py
@@ -23,7 +23,6 @@ import mimetypes
 import os
 import pprint
 import re
-import sys
 import warnings
 
 import ckanapi.errors
@@ -71,7 +70,6 @@ for extension, mimetype in [
 
 def _path_is_in_zipfile(zipfile_url, resource_path):
     zipfile_basename = os.path.splitext(os.path.basename(zipfile_url))[0]
-    zipfile_dirname = os.path.dirname(zipfile_url)
 
     if zipfile_basename == resource_path.split('/')[0]:
         return True
@@ -538,6 +536,19 @@ def main(ckan_url, ckan_apikey, gmm_yaml_path, private=False, group=None,
 
 
 def _ui(args=None):
+    """Build and operate an argparse CLI UI.
+
+    Args:
+        args=None (list): A list of string command-line parameters to provide
+            to argparse.  If ``None``, retrieval of args is left to argparse.
+
+    Returns:
+        Returns a 3-tuple with the following variables:
+
+            * host_url (str): The url of the CKAN host selected.
+            * apikey (str): The API key selected
+            * gmm_path (str): The geometamaker yml filepath
+    """
     parser = argparse.ArgumentParser(
         prog=os.path.basename(__file__),
         description=(
@@ -576,8 +587,11 @@ def _ui(args=None):
     LOGGER.info(f"User selected CKAN target {selected_host}: {host_url}")
 
     if not args.apikey:
-        apikey = os.environ[CKAN_APIKEY_ENVVARS[selected_host]]
+        envvar_key = CKAN_APIKEY_ENVVARS[selected_host]
+        LOGGER.info(f"Using API key from environment variable {envvar_key}")
+        apikey = os.environ[envvar_key]
     else:
+        LOGGER.info("Using CLI-defined API key")
         apikey = args.apikey
 
     return (

--- a/api-scripts/sync-data-to-staging.py
+++ b/api-scripts/sync-data-to-staging.py
@@ -23,10 +23,10 @@ import requests
 STAGING_URL = os.environ.get(
     'CKAN_STAGING_URL', 'https://data-staging.naturalcapitalproject.org')
 STAGING_API = f'{STAGING_URL}/api/3/action'
+STAGING_API_KEY = os.environ['CKAN_STAGING_APIKEY']
 PROD_URL = os.environ.get(
     'CKAN_PROD_URL', 'https://data.naturalcapitalproject.stanford.edu')
 PROD_API = f'{PROD_URL}/api/3/action'
-STAGING_API_KEY = os.environ['CKAN_STAGING_APIKEY']
 
 CUR_DIR = os.path.dirname(__file__)
 
@@ -126,16 +126,16 @@ def post_prod_resources_to_staging(target_package_ids=None,
                                 CUR_DIR, 'create-or-update-dataset.py')
                             logfile_path = os.path.join(
                                 temp_dir, f'{gmm_basename}.logfile')
-                            print(f"Creating dataset on {STAGING_URL} with "
+                            print(f"Creating dataset on staging with "
                                   f"{gmm_basename}")
                             with open(logfile_path, 'w') as logfile:
                                 subprocess.run(
-                                    [sys.executable, update_script, gmm_filepath],
+                                    [sys.executable, update_script,
+                                     gmm_filepath, '--staging'],
                                     stdout=logfile,
                                     stderr=subprocess.STDOUT,
                                     check=True, env={
-                                        "CKAN_URL": STAGING_URL,
-                                        "CKAN_APIKEY": STAGING_API_KEY,
+                                        "CKAN_STAGING_APIKEY": STAGING_API_KEY,
                                     })
                         except Exception:
                             print(INVALID_GMM_PACKAGE_MSG.format(


### PR DESCRIPTION
This PR modifies the create-or-update script to add an `argparse`-based CLI.  For example:

```shell
# Create on prod, api key taken from CKAN_APIKEY
python create-or-update-dataset.py test_gmm.yml
```

```shell
# create on staging, api key taken from CKAN_STAGING_APIKEY
python create-or-update-dataset.py test_gmm.yml --staging
```

```shell
# create on localhost, api key taken from CKAN_LOCAL_APIKEY
python create-or-update-dataset.py test_gmm.yml --dev
```

You can also provide an API key through the CLI by passing `--apikey=...` with your string API key to the target CKAN instance.