### PR TITLE
Always using the citation from GMM YML

### DIFF
--- a/api-scripts/create-or-update-dataset.py
+++ b/api-scripts/create-or-update-dataset.py
@@ -491,18 +491,6 @@ def main(ckan_url, ckan_apikey, gmm_yaml_path, private=False, group=None,
                 pkg_dict = catalog.action.package_show(name_or_id=name)
                 LOGGER.info(f"Package already exists name={name}")
 
-                # The suggested citation is not yet in geometamaker (see
-                # https://github.com/natcap/geometamaker/issues/17), but it can
-                # be set by CKAN.
-                #
-                # Once we know which part of the MCF we should use for the
-                # suggested citation, we can just insert it into
-                # `pkg_dict['suggested_citation']`, assuming we don't change
-                # the key in the ckanext-scheming schema.
-                if 'suggested_citation' in pkg_dict:
-                    package_parameters['suggested_citation'] = (
-                        pkg_dict['suggested_citation'])
-
                 pkg_dict = catalog.action.package_update(
                     id=pkg_dict['id'],
                     **package_parameters


### PR DESCRIPTION
This fixes a small bug in the create-or-update script where a preexisting suggested citation was not being overwritten by the contents of the corrected geometamaker yml file.  As noted in the script, we were waiting on the geometamaker spec to have settled on the key to use for the suggested citation, and since this has been resolved (for some time now), it's straightforward to correct.

The mentioned dataset, https://data.naturalcapitalproject.stanford.edu/dataset/sts-9d0fa49171d2e7488b37e9e24ac1dbdd58ab8d2faf023258b81a093440d252d0, now has a correct citation.

RE:#76