### PR TITLE
Change state to `active` when recreating data which has previously been deleted

### DIFF
--- a/api-scripts/create-or-update-dataset.py
+++ b/api-scripts/create-or-update-dataset.py
@@ -503,6 +503,11 @@ def main(ckan_url, ckan_apikey, gmm_yaml_path, private=False, group=None,
                     package_parameters['suggested_citation'] = (
                         pkg_dict['suggested_citation'])
 
+                if pkg_dict['state'] == 'deleted':
+                    LOGGER.info(f"Dataset {title} (name: {name}) exists in "
+                                "deleted state. Setting state to active.")
+                    package_parameters['state'] = 'active'
+
                 pkg_dict = catalog.action.package_update(
                     id=pkg_dict['id'],
                     **package_parameters


### PR DESCRIPTION
Changes `state` from `deleted` to `active` when you try to re-add a dataset (using `create-or-update-dataset.py`) that has been soft-deleted (not purged). 

Metadata will be pulled from the `.yml` and will overwrite the deleted dataset's metadata, if different. 

Fixes #136