### PR TITLE
Add directory for one-off scripts

### DIFF
--- a/api-scripts/one-off-scripts/create-place-vocabulary.py
+++ b/api-scripts/one-off-scripts/create-place-vocabulary.py
@@ -1,5 +1,15 @@
+"""A script used for creating the `place` Tag Vocabulary on CKAN.
+
+Includes a list of TAGS to create within the `place` vocabulary. These were
+extracted from the existing datasets' "extras" on the production Hub on 2025-07-11.
+
+Note: The initial list of extracted "placenames" included "CONUS" and
+"CONTINENTIAL US" [sic]. These two tags seemed redundant, so we elected to leave
+them out until we decided which terminology to use.
+"""
 import os
 import requests
+
 import ckanapi.errors
 from ckanapi import RemoteCKAN
 

--- a/api-scripts/one-off-scripts/create-place-vocabulary.py
+++ b/api-scripts/one-off-scripts/create-place-vocabulary.py
@@ -1,0 +1,37 @@
+import os
+import requests
+import ckanapi.errors
+from ckanapi import RemoteCKAN
+
+
+DEV_APIKEY = os.environ.get('CKAN_LOCAL_APIKEY')
+DEV_CKAN_URL = "https://localhost:8443"
+STAGING_APIKEY = os.environ.get('CKAN_STAGING_APIKEY')
+STAGING_CKAN_URL = "https://data-staging.naturalcapitalproject.org"
+PROD_APIKEY = os.environ.get('CKAN_APIKEY')
+PROD_CKAN_URL = "https://data.naturalcapitalproject.stanford.edu"
+
+TAGS = [
+    {'name': 'UNITED STATES'},
+    {'name': 'PUERTO RICO'},
+    {'name': 'US VIRGIN ISLANDS'},
+    {'name': 'PACIFIC ISLANDS'},
+    {'name': 'US TERRITORIES'},
+    {'name': 'ALASKA'},
+    {'name': 'HAWAII'},
+    {'name': 'GLOBAL'}
+]
+
+
+def vocab_create(ckan_apikey, ckan_url, vocab_name, vocab_tags):
+
+    session = requests.Session()
+    session.headers.update({'Authorization': ckan_apikey})
+    session.verify = True
+
+    with RemoteCKAN(ckan_url, apikey=ckan_apikey, session=session) as catalog: 
+        catalog.action.vocabulary_create(name=vocab_name, tags=vocab_tags)
+
+
+if __name__ == "__main__":
+    vocab_create(DEV_APIKEY, DEV_CKAN_URL, "place", TAGS)

--- a/api-scripts/one-off-scripts/parse_placenames_from_package_extras.ipynb
+++ b/api-scripts/one-off-scripts/parse_placenames_from_package_extras.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a6fdeb58-9fc5-46a6-93d6-a5ec2d839ccb",
+   "metadata": {},
+   "source": [
+    "#### Purpose:\n",
+    "\n",
+    "This notebook contains the code used to extract the \"placenames\" from our dataset package extras so that the `place` tag vocabulary could be created with tags for our currently-in-use placenames included.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b59a61da-826a-4cf9-acd4-412a825c9afb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/megannissel/miniforge3/envs/hub-jupyter/lib/python3.12/site-packages/ckanapi/version.py:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.\n",
+      "  import pkg_resources\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import requests\n",
+    "import ckanapi.errors\n",
+    "from ckanapi import RemoteCKAN\n",
+    "\n",
+    "PROD_API_KEY = os.environ.get('CKAN_APIKEY')\n",
+    "PROD_SITE_URL = \"https://data.naturalcapitalproject.stanford.edu\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "29deec51-dcb6-41e8-828d-0a661dfe5c9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_extras(ckan_url, ckan_apikey, verify=True):\n",
+    "    session = requests.Session()\n",
+    "    session.headers.update({'Authorization': ckan_apikey})\n",
+    "    session.verify = verify\n",
+    "\n",
+    "    with RemoteCKAN(ckan_url, apikey=ckan_apikey, session=session) as catalog:\n",
+    "        datasets = catalog.action.package_list()\n",
+    "\n",
+    "        pkg_extras = {}\n",
+    "        for dataset in datasets:\n",
+    "            pkg = catalog.action.package_show(id=dataset)\n",
+    "            pkg_extras[dataset] = pkg.get('extras', [])\n",
+    "\n",
+    "    return pkg_extras"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6434d999-7d39-47b7-9e9b-8f03feb2e27a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prod_data = extract_extras(PROD_SITE_URL, PROD_API_KEY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c1f3c27c-c271-4348-8170-3304bf471155",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def placenames_by_dataset(data):\n",
+    "    placenames_mapping = {}\n",
+    "    for pkg_id, extras in data.items():\n",
+    "        for extra in extras:\n",
+    "            if extra.get('key', '') == 'placenames':\n",
+    "                placenames_mapping[pkg_id] = json.loads(extra['value'])\n",
+    "                break\n",
+    "    return placenames_mapping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d17e53ae-3ea2-4dad-936d-4a03653470e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pkg_placenames = placenames_by_dataset(prod_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "44b32241-f10e-4953-8079-c10e77bca287",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def placenames_set(pkg_placenames):\n",
+    "    all_placenames = []\n",
+    "    for v in pkg_placenames.values():\n",
+    "        all_placenames.extend(v)\n",
+    "    return set(all_placenames)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e17d9f12-8f6c-449d-aa56-61b895424fcd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_placenames = placenames_set(pkg_placenames)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f6ef833c-3d4e-43f4-bb66-9360e26a2b91",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'GLOBAL',\n",
+       " 'PACIFIC ISLANDS',\n",
+       " 'PUERTO RICO',\n",
+       " 'UNITED STATES',\n",
+       " 'US VIRGIN ISLANDS'}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all_placenames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "990f75e2-e3df-4165-b9c1-f49b7604198b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hub-jupyter",
+   "language": "python",
+   "name": "hub-jupyter"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a new directory inside of `api-scripts`, `one-off-scripts`, where we can stick miscellaneous utility scripts / notebooks / etc. that were useful at one point or another in our Data Hub development process. 

I've included the script I used to create the `place` tag vocabulary (it doesn't have a neat CLI like our other API scripts), as well as a jupyter notebook I used to extract the `placenames` from our existing package "extras" on the production Hub (this was the list of placenames that I used when creating tags in the `place` vocabulary). 