### PR TITLE
clipping-service: Set CORS headers programmatically; helper `make` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deploy deploy-staging sync-on-prod fetch-nginx-config clipping-service
+.PHONY: deploy deploy-staging sync-on-prod fetch-nginx-config clipping-service env-clip ckan-dev
 
 GIT_DIR := /opt/ckan-catalog/data.naturalcapitalproject.stanford.edu
 CKAN_PROD_URL := https://data.naturalcapitalproject.stanford.edu

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,7 @@ env-clip:
 
 clipping-service:
 	python -m gunicorn --chdir ./clipping-service/app app:app --reload
+
+ckan-dev:
+	docker compose -f docker-compose.dev.yml build
+	docker compose -f docker-compose.dev.yml up --watch

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deploy deploy-staging sync-on-prod fetch-nginx-config
+.PHONY: deploy deploy-staging sync-on-prod fetch-nginx-config clipping-service
 
 GIT_DIR := /opt/ckan-catalog/data.naturalcapitalproject.stanford.edu
 CKAN_PROD_URL := https://data.naturalcapitalproject.stanford.edu
@@ -24,3 +24,18 @@ fetch-nginx-config:
 	gcloud compute scp $(GCLOUD_COMMON_ARGS) $(PROD_VM_NAME):/etc/nginx/sites-enabled/ckan  host-nginx/etc.nginx.sites-available.ckan
 	gcloud compute scp $(GCLOUD_COMMON_ARGS) $(PROD_VM_NAME):/etc/nginx/nginx.conf          host-nginx/etc.nginx.nginx.conf
 	gcloud compute scp $(GCLOUD_COMMON_ARGS) $(PROD_VM_NAME):/etc/nginx/throttle-bots.conf  host-nginx/etc.nginx.throttle-bots.conf
+
+
+# Targets for local development:
+CLIP_ENV := clipenv
+
+env-clip:
+	conda create -n $(CLIP_ENV) -y -c conda-forge python=3.12
+	conda env update -n $(CLIP_ENV) --file ./clipping-service/app/requirements.txt
+	conda env config vars set -n $(CLIP_ENV) DEV_MODE=True
+	@echo "To activate the environment and run the clipping service:"
+	@echo ">> conda activate $(CLIP_ENV)"
+	@echo ">> make clipping-service"
+
+clipping-service:
+	python -m gunicorn --chdir ./clipping-service/app app:app --reload

--- a/clipping-service/app/app.py
+++ b/clipping-service/app/app.py
@@ -24,20 +24,22 @@ from osgeo import gdal
 from osgeo import osr
 
 app = flask.Flask(__name__, template_folder='templates')
+
+cors_origins = [
+    'https://data-staging.naturalcapitalproject.org',
+    'https://data.naturalcapitalproject.stanford.edu'
+]
+
+if os.environ.get("DEV_MODE"):
+    cors_origins.append("https://localhost:*")
+
 CORS(app, resources={
     '/*': {
-        'origins': [
-            # Only use localhost for local development.
-            # 'http://localhost:*',
-            # 'https://localhost:*',
-            # 'http://127.0.0.1:*',
-            'https://data-staging.naturalcapitalproject.org',
-            'https://data.naturalcapitalproject.stanford.edu',
-        ]
+        'origins': cors_origins
     }
 })
-logging.basicConfig(level=logging.DEBUG)
 
+logging.basicConfig(level=logging.DEBUG)
 
 # PLAN: write a logging handler to listen for progress messages and send those
 # to the client.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,6 +36,8 @@ services:
       - redisnet
     env_file:
       - .env
+    environment:
+      - CKANEXT__MAPPREVIEW__CLIPPING_SERVICE_URL=http://localhost:8000
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Partially addresses #147; builds on PR #140 

In PR #140, I moved the clipping service URL into an environment variable, which lets us more easily point a local CKAN cluster to a locally-running clipping service. However, in order to run the local clipping service, you still had to manually update the acceptable origins in the CORS headers in `clipping-service/app/app.py`. Not only does this feel like a bad workflow, but it also leaves the door open to accidentally committing changes with `localhost` still included in the list of acceptable headers -- which isn't something we want. 

Another problem with the state of clipping service dev post-#140 is the environment: the service requires certain dependencies to run, and it'd be handy to have a single command to create the environment and install those dependencies. As I started thinking about make targets, I realized I could potentially solve two problems at once: we could set an environment variable in the dev env that we could then check in `clipping-service/app/app.py` to determine if we're in development or not; if we are, add `localhost` to the acceptable origins in the CORS headers.

In this iteration, I ended up with one target for building the dev environment and a second one for running the service. I considered trying to write a single target that does both, but figured doing it this way has the upside of not needing to re-create the environment every time (since I suspect the dependencies in the env itself are less likely to change regularly than the clipping service code). 

Additionally, since the CORS headers of the production clipping service disallow requests from localhost, there's not much reason to point to the production service from a local CKAN cluster. Since we already have a separate docker compose file for CKAN dev, rather than editing our `.env` file, we can take advantage of docker compose's environment variable [precedence rules](https://docs.docker.com/compose/how-tos/environment-variables/envvars-precedence/) and set `CKANEXT__MAPPREVIEW__CLIPPING_SERVICE_URL=http://localhost:8000` within `docker-compose.dev.yml`. 

I've gone ahead and added a make target for building and running the dev compose cluster as well. 