### PR TITLE
Fix GeoJSON stored in `spatial` extra

### DIFF
--- a/api-scripts/create-or-update-dataset.py
+++ b/api-scripts/create-or-update-dataset.py
@@ -293,7 +293,7 @@ def _get_wgs84_bbox(config):
 
     try:
         minx, miny, maxx, maxy = pygeoprocessing.transform_bounding_box(
-            [minx, maxx, miny, maxy], source_srs_wkt, dest_srs_wkt)
+            [minx, miny, maxx, maxy], source_srs_wkt, dest_srs_wkt)
     except (ValueError, RuntimeError):
         LOGGER.error(
             f"Failed to transform bounding box from {source_srs_wkt} "


### PR DESCRIPTION
Fixes the last piece of #153 (the malformed GeoJSON part)

After we got spatial search working again, I noticed that the search results weren't returning the expected datasets. Turns out, when converting the GMM YML bounding boxes to GeoJSON, we had the coordinates order wrong in the `pygeoprocessing.transform_bounding_box` call. Once this is merged in, we will need to re-run `create_or_update_dataset.py` on all datasets that include bounding box information in order to update the data stored in `spatial`. 