### PR TITLE
Remove tags/groups from organization page

### DIFF
--- a/host-nginx/etc.nginx.sites-available.ckan
+++ b/host-nginx/etc.nginx.sites-available.ckan
@@ -38,11 +38,9 @@ server {
 	}
 	location = /organization/natcap/ {
 		include /etc/nginx/throttle-bots.conf;
-		include /etc/nginx/ckan-proxy.conf;
 	}
 	location = /organization/48bdf034-675f-4017-970f-738a5b7869ce {
 		include /etc/nginx/throttle-bots.conf;
-		include /etc/nginx/ckan-proxy.conf;
 	}
 
 	# Need this here for the homepage and any resources accessible off of the home page.

--- a/host-nginx/etc.nginx.sites-available.ckan
+++ b/host-nginx/etc.nginx.sites-available.ckan
@@ -36,11 +36,13 @@ server {
 		include /etc/nginx/throttle-bots.conf;
 		include /etc/nginx/ckan-proxy.conf;
 	}
-	location = /organization/natcap/ {
+	location = /organization/natcap {
 		include /etc/nginx/throttle-bots.conf;
+		include /etc/nginx/ckan-proxy.conf;
 	}
 	location = /organization/48bdf034-675f-4017-970f-738a5b7869ce {
 		include /etc/nginx/throttle-bots.conf;
+		include /etc/nginx/ckan-proxy.conf;
 	}
 
 	# Need this here for the homepage and any resources accessible off of the home page.

--- a/src/ckanext-natcap/ckanext/natcap/plugin.py
+++ b/src/ckanext-natcap/ckanext/natcap/plugin.py
@@ -340,7 +340,8 @@ class NatcapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         # the existing facets provided.
         # Handling organization facets due to https://github.com/natcap/data.naturalcapitalproject.stanford.edu/issues/59
         # See interface prototype at https://github.com/ckan/ckan/blob/042f6ffd3662e3a41e63a41b9b0c7079decb3b29/ckan/plugins/interfaces.py#L1659
-        return facets_dict
+        # To add facets (tags/groups) to organization page, return facets_dict
+        return {}
 
     def before_dataset_search(self, search_params: dict[str, Any]):
         # Check for topic facet and add tags if found


### PR DESCRIPTION
Remove poorly formed tags and groups (organization facets) from the natcap organization page. I also removed the trailing slash when setting the location for the `/organization/natcap` page in an attempt to get this page to work as ckan prefers this. 

Fixes #71 