### PR TITLE
Make subfolders in data packages collapsible

### DIFF
--- a/src/ckanext-natcap/ckanext/natcap/assets/css/natcap.css
+++ b/src/ckanext-natcap/ckanext/natcap/assets/css/natcap.css
@@ -275,7 +275,7 @@ body {
     border-top: 1px solid var(--color-gray);
 }
 
-.resources .nested-source-list li {
+.resources .nested-source-list {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -283,13 +283,22 @@ body {
     flex-direction: column;
 }
 
-.resources .nested-source-list.indent-0 .resource-item-description {
-    padding-left: calc(2 * var(--resource-item-padding));
+
+.resources .nested-source-list {
+--step: 16px;                         /* per-level indent */
+--base: calc(2 * var(--resource-item-padding));  /* baseline padding used before */
 }
 
-.resources .nested-source-list.indent-1 .resource-item-description {
-    padding-left: calc(4 * var(--resource-item-padding));
-}
+/* depth variables */
+.resources .nested-source-list.indent-0 { --level: 0; }
+.resources .nested-source-list.indent-1 { --level: 1; }
+
+
+/* Apply indent to the entire row so caret + icon + name move together */
+.resources .nested-source-list > li > .src-acc > .src-summary,
+.resources .nested-source-list > li.src-file > a.heading {
+padding-left: calc(var(--base) + var(--level) * var(--step));
+} 
 
 .resources .nested-source-item {
     display: flex;
@@ -1263,14 +1272,11 @@ div#invest-model-list-container div {
 .src-acc > summary { list-style: none; }
 
 /* Folder headers (nested) */
-.src-summary,
-.src-summary--root {
+.src-summary {
   display: flex; align-items: center; gap: 8px;
-  padding: 6px 8px; margin: 6px 0;
-  /* background: #f7f7f7; border: 1px solid #e6e6e6; border-radius: 8px; */
+  padding: 6px 8px; margin: 2px 0;
   cursor: pointer; user-select: none;
 }
-.src-summary--root { cursor: default; } /* top-level is open, not clickable */
 
 .src-caret {
   width: 0; height: 0;

--- a/src/ckanext-natcap/ckanext/natcap/assets/css/natcap.css
+++ b/src/ckanext-natcap/ckanext/natcap/assets/css/natcap.css
@@ -1256,3 +1256,31 @@ div#invest-model-list-container div {
 #invest-model-list-container .nav-pills .nav-link.active {
     background-color: var(--color-blue);
 }
+
+
+/* Hide native marker; use custom caret */
+.src-acc > summary::-webkit-details-marker { display: none; }
+.src-acc > summary { list-style: none; }
+
+/* Folder headers (nested) */
+.src-summary,
+.src-summary--root {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 8px; margin: 6px 0;
+  /* background: #f7f7f7; border: 1px solid #e6e6e6; border-radius: 8px; */
+  cursor: pointer; user-select: none;
+}
+.src-summary--root { cursor: default; } /* top-level is open, not clickable */
+
+.src-caret {
+  width: 0; height: 0;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-left: 6px solid currentColor;
+  transition: transform .15s ease;
+}
+.src-acc[open] > .src-summary .src-caret { transform: rotate(90deg); }
+
+/* Indentation for children */
+.resource-directory-contents { margin-left: 16px; }
+

--- a/src/ckanext-natcap/ckanext/natcap/assets/css/natcap.css
+++ b/src/ckanext-natcap/ckanext/natcap/assets/css/natcap.css
@@ -275,7 +275,7 @@ body {
     border-top: 1px solid var(--color-gray);
 }
 
-.resources .nested-source-list {
+.resources .nested-source-list li {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -285,19 +285,21 @@ body {
 
 
 .resources .nested-source-list {
---step: 16px;                         /* per-level indent */
---base: calc(2 * var(--resource-item-padding));  /* baseline padding used before */
+    --step: 16px;                         /* per-level indent */
+    --base: calc(2 * var(--resource-item-padding));  /* baseline padding used before */
 }
 
 /* depth variables */
 .resources .nested-source-list.indent-0 { --level: 0; }
 .resources .nested-source-list.indent-1 { --level: 1; }
+.resources .nested-source-list.indent-2 { --level: 2; }
+.resources .nested-source-list.indent-2 { --level: 3; }
 
 
 /* Apply indent to the entire row so caret + icon + name move together */
 .resources .nested-source-list > li > .src-acc > .src-summary,
 .resources .nested-source-list > li.src-file > a.heading {
-padding-left: calc(var(--base) + var(--level) * var(--step));
+    padding-left: calc(var(--base) + var(--level) * var(--step));
 } 
 
 .resources .nested-source-item {
@@ -1287,6 +1289,4 @@ div#invest-model-list-container div {
 }
 .src-acc[open] > .src-summary .src-caret { transform: rotate(90deg); }
 
-/* Indentation for children */
-.resource-directory-contents { margin-left: 16px; }
 

--- a/src/ckanext-natcap/ckanext/natcap/templates/package/snippets/sources_list.html
+++ b/src/ckanext-natcap/ckanext/natcap/templates/package/snippets/sources_list.html
@@ -4,8 +4,7 @@
   {% for source in sources %}
     {% set name = source.name or '' %}
     {% set children = source.children if source.children is defined else [] %}
-    {% set is_dir = (children|length > 0) or (source.type == 'directory') or (name.endswith('/')) %}
-
+    {% set is_dir = source.type == 'directory' %}
     {% if is_dir %}
       {% set label = name.rstrip('/').rsplit('/', 1)[-1] %}
     {% else %}

--- a/src/ckanext-natcap/ckanext/natcap/templates/package/snippets/sources_list.html
+++ b/src/ckanext-natcap/ckanext/natcap/templates/package/snippets/sources_list.html
@@ -22,7 +22,6 @@
                   <img src="/img/icon-filetype-directory.png" alt="" />
                 </div>
                 <div class="resource-item-name">{{ label }}</div>
-
               </div>
             </summary>
             <div class="resource-directory-contents">

--- a/src/ckanext-natcap/ckanext/natcap/templates/package/snippets/sources_list.html
+++ b/src/ckanext-natcap/ckanext/natcap/templates/package/snippets/sources_list.html
@@ -1,16 +1,18 @@
-{# All directories are collapsible (closed by default), files are normal rows. #}
+{# All directories are collapsible (closed by default); files are normal rows. #}
 
 <ol class="nested-source-list indent-{{ indent }}">
   {% for source in sources %}
     {% set name = source.name or '' %}
-    {% set parts = name.split('.') %}
     {% set children = source.children if source.children is defined else [] %}
     {% set is_dir = (children|length > 0) or (source.type == 'directory') or (name.endswith('/')) %}
 
-    {# Keep your filtering for displayable files #}
+    {% if is_dir %}
+      {% set label = name.rstrip('/').rsplit('/', 1)[-1] %}
+    {% else %}
+      {% set label = name.rsplit('/', 1)[-1].rsplit('.', 1)[0] %}
+    {% endif %}
+   
     {% if is_dir or h.natcap_show_resource(name) %}
-
-      {# ----------------- FOLDER (always collapsible) ----------------- #}
       {% if is_dir %}
         <li class="nested-source-item src-folder" data-level="{{ indent }}">
           <details class="src-acc">
@@ -20,19 +22,15 @@
                 <div class="resource-item-type">
                   <img src="/img/icon-filetype-directory.png" alt="" />
                 </div>
-                <div class="resource-item-name">
-                  {{ (parts[0] if parts else name).rstrip('/') }}/
-                </div>
+                <div class="resource-item-name">{{ label }}</div>
+
               </div>
             </summary>
-
             <div class="resource-directory-contents">
               {% snippet 'package/snippets/sources_list.html', sources=children, indent=indent+1 %}
             </div>
           </details>
         </li>
-
-      {# ----------------- FILE ----------------- #}
       {% else %}
         <li class="nested-source-item src-file" data-level="{{ indent }}">
           <a class="heading" href="{{ source.url }}" aria-label="{{ _('Download resource: {fn}').format(fn=name) }}">
@@ -43,15 +41,12 @@
                   {{ h.natcap_get_ext(name) }}
                 </div>
               {% endif %}
-              <div class="resource-item-name">
-                {{ parts[0] }}
-              </div>
+              <div class="resource-item-name">{{ label }}</div>
             </div>
             <div class="icon-button icon-button-download"></div>
           </a>
         </li>
       {% endif %}
-
     {% endif %}
   {% endfor %}
 </ol>

--- a/src/ckanext-natcap/ckanext/natcap/templates/package/snippets/sources_list.html
+++ b/src/ckanext-natcap/ckanext/natcap/templates/package/snippets/sources_list.html
@@ -1,36 +1,57 @@
+{# All directories are collapsible (closed by default), files are normal rows. #}
+
 <ol class="nested-source-list indent-{{ indent }}">
   {% for source in sources %}
-    {% set parts = source.name.split('.') %}
-    {% if source.type == 'directory' or h.natcap_show_resource(source.name) %}
-      <li class="nested-source-item">
-        <a class="heading" href="{{ source.url }}" aria-label="{{ _('Download resource: {name_or_id}').format(name_or_id=name_or_id)}}">
-          <div class="resource-item-description">
-            {% if source.type != 'directory' and h.natcap_show_icon(source.name) %}
-              <div class="resource-item-type">
-                <img src="/img/icon-filetype-{{ h.natcap_get_resource_type_icon_slug(source.name) }}.png" />
-                {{ h.natcap_get_ext(source.name) }}
-              </div>
-            {% elif source.type == 'directory' %}
-              <div class="resource-item-type">
-                <img src="/img/icon-filetype-directory.png" />
-              </div>
-            {% endif %}
+    {% set name = source.name or '' %}
+    {% set parts = name.split('.') %}
+    {% set children = source.children if source.children is defined else [] %}
+    {% set is_dir = (children|length > 0) or (source.type == 'directory') or (name.endswith('/')) %}
 
-            <div class="resource-item-name">
-              {{ parts[0] }}{% if source.type == 'directory' %}/{% endif %}
+    {# Keep your filtering for displayable files #}
+    {% if is_dir or h.natcap_show_resource(name) %}
+
+      {# ----------------- FOLDER (always collapsible) ----------------- #}
+      {% if is_dir %}
+        <li class="nested-source-item src-folder" data-level="{{ indent }}">
+          <details class="src-acc">
+            <summary class="src-summary">
+              <span class="src-caret" aria-hidden="true"></span>
+              <div class="resource-item-description">
+                <div class="resource-item-type">
+                  <img src="/img/icon-filetype-directory.png" alt="" />
+                </div>
+                <div class="resource-item-name">
+                  {{ (parts[0] if parts else name).rstrip('/') }}/
+                </div>
+              </div>
+            </summary>
+
+            <div class="resource-directory-contents">
+              {% snippet 'package/snippets/sources_list.html', sources=children, indent=indent+1 %}
             </div>
-          </div>
+          </details>
+        </li>
 
-        {% if source.type == 'directory' %}
-          <div class="resource-directory-contents">
-            {% snippet 'package/snippets/sources_list.html',sources=source.children,indent=indent+1 %}
-          </div>
-        {% else %}
-          <div class="icon-button icon-button-download">
-          </div>
-        {% endif %}
-        </a>
-      </li>
+      {# ----------------- FILE ----------------- #}
+      {% else %}
+        <li class="nested-source-item src-file" data-level="{{ indent }}">
+          <a class="heading" href="{{ source.url }}" aria-label="{{ _('Download resource: {fn}').format(fn=name) }}">
+            <div class="resource-item-description">
+              {% if h.natcap_show_icon(name) %}
+                <div class="resource-item-type">
+                  <img src="/img/icon-filetype-{{ h.natcap_get_resource_type_icon_slug(name) }}.png" alt="" />
+                  {{ h.natcap_get_ext(name) }}
+                </div>
+              {% endif %}
+              <div class="resource-item-name">
+                {{ parts[0] }}
+              </div>
+            </div>
+            <div class="icon-button icon-button-download"></div>
+          </a>
+        </li>
+      {% endif %}
+
     {% endif %}
   {% endfor %}
 </ol>


### PR DESCRIPTION
This PR makes every directory in the "sources" tree render as a collapsible accordion (which is closed by default). Each item is treated as a folder (which can be collapsed/expanded) if type is directory, it has children or ends with `/`. There is no change to how files can be downloaded (i.e., this PR does not add folder download functionality).
 

<img width="426" height="358" alt="Screenshot 2025-09-26 at 4 59 06 PM" src="https://github.com/user-attachments/assets/98101c0f-9e35-4d68-82e1-24b08d872cf7" />




Fixes #162 
