### PR TITLE
Allow long strings to wrap in dataset descriptions

### DIFF
--- a/src/ckanext-natcap/ckanext/natcap/assets/css/natcap.css
+++ b/src/ckanext-natcap/ckanext/natcap/assets/css/natcap.css
@@ -1304,3 +1304,8 @@ div#invest-model-list-container div {
     pointer-events: none; /* keeps it inert if someone wraps it with <a> by mistake */
     padding-left: calc(var(--base) + var(--level) * var(--step));
   }
+
+.package-description {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}


### PR DESCRIPTION
This PR prevents layout issues by adding CSS rules to allow long unbroken strings (typically URLs) in a dataset's description to wrap naturally instead of overflowing their container (into the mappreview). Out of an abundance of caution, uses both `overflow-wrap: anywhere` and `word-break: break-word` to support all browsers. 

Fixes #176