### PR TITLE
Create 3Ps Cook Islands Config File

### DIFF
--- a/src/ckanext-natcap/ckanext/natcap/public/dataset_configs/People, Planet, Prosperity Pilot Country Data Package - Cook Islands.yml
+++ b/src/ckanext-natcap/ckanext/natcap/public/dataset_configs/People, Planet, Prosperity Pilot Country Data Package - Cook Islands.yml
@@ -1,0 +1,7 @@
+# Default policy if no rule matches
+defaults:
+  allow: true
+  # Note: folders are _not_ downloadable by default (assumes no zipfile created)
+
+layers_to_preview:
+- Cook_Islands_3Ps_data_pkg/Model_inputs_outputs/FloodRisk_Raro_Muri/FloodRisk_inputs/watersheds_Muri/watersheds_Muri.shp


### PR DESCRIPTION
Addition of the 3Ps Cook Islands Config file. 

Only one file was requested to be visualized: 
`Cook_Islands_3Ps_data_pkg/Model_inputs_outputs/FloodRisk_Raro_Muri/FloodRisk_inputs/watersheds_Muri/watersheds_Muri.shp
`
There are no other rules or download restrictions. 

The package can be found on GCP [here.](https://console.cloud.google.com/storage/browser/natcap-data-cache/natcap-projects/PeoplePlanetProsperity_Country_Data/Cook_Islands?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&project=sdss-natcap-gef-ckan)