### PR TITLE
Adjust logic for setting map default view

### DIFF
--- a/src/ckanext-mappreview/ckanext/mappreview/assets/js/mappreview.js
+++ b/src/ckanext-mappreview/ckanext/mappreview/assets/js/mappreview.js
@@ -159,9 +159,6 @@ ckan.module("mappreview", function ($, _) {
         container: 'map',
         style: globalConfig.mapbox_style,
         bounds: config.map.bounds,
-        zoom: config.map.minzoom + 2,
-        minZoom: config.map.minzoom,
-        maxZoom: config.map.maxzoom,
       });
       map.addControl(new mapboxgl.FullscreenControl({}), 'top-left');
       map.addControl(new mapboxgl.ScaleControl({maxWidth: 80, unit: 'metric'}), 'bottom-left');
@@ -263,8 +260,9 @@ ckan.module("mappreview", function ($, _) {
           }
       }
 
-        if (isGlobal(boundsArray)){
-          map.setCenter([0,0], {zoom:1})
+        if (isGlobal(boundsArray)) {
+          map.setCenter([0,0]);
+          map.setMinZoom(1);
           let userInteracting = false;
           spinGlobe(userInteracting);
           // Stop spinning if user moves mouse onto map
@@ -277,15 +275,13 @@ ckan.module("mappreview", function ($, _) {
             spinGlobe(userInteracting);
           });
         } else if (config.layers.length === 1 && config.layers[0].type === 'vector' && (
-          'center_lat_lon' in layers[0])){
+          'center_lat_lon' in layers[0])) {
           const centerLatLon =  layers[0].center_lat_lon;
           if (centerLatLon) {
             // mapbox uses long, lat format
             map.setCenter([centerLatLon[1], centerLatLon[0]]);
-            // zoom level conservatively set to the min zoom of full dataset
-            map.setZoom(config.map.minzoom);
           }
-        } else{ // bounds aren't global, and map doesn't just show 1 vector layer
+        } else { // bounds aren't global, and map doesn't just show 1 vector layer
           map.fitBounds(boundsArray, { padding: 20, linear: true});
         }
 


### PR DESCRIPTION
Fixes #185 

For datasets with only a single vector layer, we end up with the default zoom set to our minzoom value of 1. This means that if the dataset covers a very small area, it's not visible on the initial map since it's zoomed out to show the whole globe. I think instead we can just rely on the bounds in the map config and (in the case of these single-layer vector datasets) the centerLatLon. 

I also don't think we necessarily need to be setting the minzoom and maxzoom at all. Sure, it prevents someone from zooming out until all the layers disappear, but I'm not sure that's a problem. In the case of the Colombia package, I've been bothered by how the map wasn't letting you zoom out to the point where the whole layer was visible within the viewport, and removing the minzoom restriction solves this. 

I double-checked how the map looks for each dataset I currently have on my local CKAN instance and most look exactly the same. Biggest differences: the Colombia package is slightly farther zoomed out (the whole bounding box is visible within the viewport); the Cook Islands package is zoomed into the layer rather than showing the whole globe. 