### PR TITLE
Fix clipping service upload path

### DIFF
--- a/clipping-service/app/app.py
+++ b/clipping-service/app/app.py
@@ -55,9 +55,9 @@ SOURCE_LOGGER = logging.getLogger('pygeoprocessing')
 SOURCE_LOGGER.setLevel(logging.DEBUG)
 GOOGLE_STORAGE_URL = 'https://storage.googleapis.com'
 TRUSTED_BUCKET = f'{GOOGLE_STORAGE_URL}/natcap-data-cache'
-TARGET_BUCKET_PATH = 'jupyter-app-temp-storage/clipped'
-TARGET_FILE_BUCKET = f'gs://{TARGET_BUCKET_PATH}'
-TARGET_BUCKET_URL = f'{GOOGLE_STORAGE_URL}/{TARGET_BUCKET_PATH}'
+TARGET_FILE_BUCKET = 'gs://jupyter-app-temp-storage'
+TARGET_BUCKET_SUBDIR = 'clipped'
+TARGET_BUCKET_URL = f'{GOOGLE_STORAGE_URL}/jupyter-app-temp-storage/{TARGET_BUCKET_SUBDIR}'
 WORKSPACE_DIR = os.environ.get('WORKSPACE_DIR', os.getcwd())
 app.logger.info("WORKSPACE_DIR: %s", WORKSPACE_DIR)
 pygeoprocessing.geoprocessing._LOGGING_PERIOD = 1.0
@@ -363,7 +363,7 @@ def clip():
         bucketname = re.sub('^gs://', '', TARGET_FILE_BUCKET)
         storage_client = storage.Client()
         bucket = storage_client.bucket(bucketname)
-        blob = bucket.blob(bucket_filename)
+        blob = bucket.blob(f"{TARGET_BUCKET_SUBDIR}/{bucket_filename}")
         blob.upload_from_filename(target_file_path)
     except Exception:
         app.logger.exception("Falling back to cmdline gsutil")


### PR DESCRIPTION
When updating the upload path in preparation for the new Cloud Armor policy, we mixed up where to include the folder name. Since GCS doesn't have real folders / directories, we need to prefix the upload file _name_ with the folder name, not append the folder name to the bucket name. This is an important distinction when establishing a connection to the bucket and creating the blob to upload. 