### PR TITLE
Patch CVEs in tiling service gunicorn install

### DIFF
--- a/clipping-service/app/requirements.txt
+++ b/clipping-service/app/requirements.txt
@@ -5,4 +5,4 @@ humanize
 flask_cors
 pyyaml
 uvicorn
-gunicorn
+gunicorn >= 22


### PR DESCRIPTION
Addresses two CVEs that came up in a Wiz scan:

* CVE-2024-1135
* CVE-2024-6827

Fixes #196 