### PR TITLE
Addressing gunicorn version in titiler as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deploy deploy-staging sync-on-prod fetch-nginx-config clipping-service env-clip ckan-dev
+.PHONY: deploy deploy-staging sync-on-prod fetch-nginx-config clipping-service env-clip ckan-dev tileserver
 
 GIT_DIR := /opt/ckan-catalog/data.naturalcapitalproject.stanford.edu
 CKAN_PROD_URL := https://data.naturalcapitalproject.stanford.edu
@@ -39,6 +39,9 @@ env-clip:
 
 clipping-service:
 	python -m gunicorn --chdir ./clipping-service/app app:app --timeout 180 --reload
+
+tileserver:
+	python -m gunicorn --chdir ./tileserver/app main:app --timeout 180 --reload
 
 ckan-dev:
 	docker compose -f docker-compose.dev.yml build

--- a/tileserver/Dockerfile
+++ b/tileserver/Dockerfile
@@ -2,11 +2,11 @@
 FROM ghcr.io/developmentseed/titiler@sha256:1436b4f43743c11da3661c90f7b59f1065578bf48fbdf198db2c7235d7293447
 
 COPY ./app /app
-RUN python -m pip install matplotlib aiocache[redis] pydantic-settings google-cloud-logging
+RUN python -m pip install matplotlib aiocache[redis] pydantic-settings google-cloud-logging "gunicorn>=22"
 
 ENV HOST=0.0.0.0
 ENV PORT=8000
 ENV PYTHONPATH=/app
 
 # CWD is /app
-CMD python main.py
+CMD python /app/main.py


### PR DESCRIPTION
This PR addresses the gunicorn version constraint in the tileserver as well (instead of how I had accidentally done so for the clipping service in #197 ).

As it happens, rebuilding the container this morning did, in fact, resolve the CVE alert.  `gunicorn` is installed in the parent titler container, so I am assuming it's a core dependency, and must have been updated on a rebuild.

RE:#196

Also addresses (for titiler):
* CVE-2024-1135
* CVE-2024-6827