### PR TITLE
Raise a meaningful exception when key not found

### DIFF
--- a/api-scripts/create-or-update-dataset.py
+++ b/api-scripts/create-or-update-dataset.py
@@ -160,6 +160,11 @@ def _create_resource_dict_from_url(url, description):
         bucket = storage_client.bucket('natcap-data-cache')
         blob = bucket.get_blob(key)
 
+        if blob is None:
+            LOGGER.debug(f"url: {url}")
+            raise AssertionError(
+                f"Could not retrieve a file from key {key}")
+
         checksum = f"crc32c:{blob.crc32c}"
         size = blob.size
     elif url.startswith('https://drive.google.com'):


### PR DESCRIPTION
Just a minor change to raise a meaningful exception (and a little more logging) when a file cannot be found in the target bucket.

Fixes #200 