### PR TITLE
Restart nginx container unless it was stopped

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,6 +17,7 @@ services:
     depends_on:
       ckan:
         condition: service_healthy
+    restart: unless-stopped
     ports:
       - "0.0.0.0:${NGINX_SSLPORT_HOST}:${NGINX_SSLPORT}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     depends_on:
       ckan:
         condition: service_healthy
+    restart: unless-stopped
     ports:
       - "0.0.0.0:${NGINX_SSLPORT_HOST}:${NGINX_SSLPORT}"
 


### PR DESCRIPTION
With this change, the nginx container will also start (once the `ckan` service is healthy) unless the nginx container was stopped by hand.  I believe this is in line with the behavior we are looking for.  It turns out that the default for `restart` is `no`, which explains why it wasn't restarting when we thought it would.

Fixes #225