### PR TITLE
Display all Collection Tags on a Dataset

### DIFF
--- a/src/ckanext-natcap/ckanext/natcap/assets/css/natcap.css
+++ b/src/ckanext-natcap/ckanext/natcap/assets/css/natcap.css
@@ -1365,3 +1365,7 @@ div#invest-model-list-container div {
     padding: 1rem;
     margin-top: 1rem;
 }
+
+.collection-inline {
+    margin-bottom: 0rem;
+}

--- a/src/ckanext-natcap/ckanext/natcap/helpers.py
+++ b/src/ckanext-natcap/ckanext/natcap/helpers.py
@@ -191,18 +191,22 @@ def get_collection_name(collection_name):
     return dataset.get('title', '')
 
 
-def get_collection_name_url(collection_tag):
-    results = toolkit.get_action('package_search')(
-        {},
-        {
-            "fq": f'extras_collection:"{collection_tag}"',
-            "q": "type:collection",
-            "fl": "title, name",
-        }
-    )
-    if results['count'] > 0:
-        return results['results']
-    return None
+def get_collection_name_url(collection_tags):
+    tag_collection_map = {}
+    for tag in collection_tags:
+        results = toolkit.get_action('package_search')(
+            {},
+            {
+                "fq": f'extras_collection:"{tag}"',
+                "q": "type:collection",
+                "fl": "title, name",
+            }
+        )
+        if results['count'] > 0:
+            tag_collection_map[tag] = results['results']
+        else:
+            tag_collection_map[tag] = None
+    return tag_collection_map
 
 
 def collection_lulc_biotable(pkg):

--- a/src/ckanext-natcap/ckanext/natcap/templates/package/snippets/info.html
+++ b/src/ckanext-natcap/ckanext/natcap/templates/package/snippets/info.html
@@ -20,23 +20,34 @@
 
   {% block collection_info %}
   {% if pkg.collection %}
-    {% set collection_tag = pkg.collection[0] %}
+    {% set collection_tags = pkg.collection %}
 
     {% if pkg.type=='dataset' %}
-      {% set collection_packages = h.natcap_get_collection_name_url(collection_tag) %}
+      {% set collection_packages_map = h.natcap_get_collection_name_url(collection_tags) %}
       <div class="collection-info">
         <i class="fa fa-layer-group" aria-hidden="true"></i>
-        {% if not collection_packages %}
-          <span>This dataset is part of a collection: <a href="{% url_for 'dataset.search', vocab_collection=collection_tag %}">{{ collection_tag }}</a></span>
-        {% elif collection_packages|length == 1 %}
-        <span>This dataset is part of a collection: <a href="/collection/{{collection_packages[0]['name']}}">{{ collection_packages[0]['title'] }}</a></span>
+        {% if collection_tags|length == 1 %}
+        {% set collection_tag = collection_tags[0] %}
+          <span>This dataset is part of a Collection:
+            {% if collection_packages_map[collection_tag] %}
+            {% set collection_package = collection_packages_map[collection_tag][0] %}
+            <a href="/collection/{{collection_package['name']}}">{{ collection_package['title'] }}</a>
+            {% else %}
+            <a href="{% url_for 'dataset.search', vocab_collection=collection_tag %}">{{ collection_tag }}</a>
+            {% endif %}
+          </span>
         {% else %}
-        <span>This dataset is part of these collections:</span>
-        <ul>
-          {% for coll_pkg in collection_packages %}
-          <li><a href="/collection/{{coll_pkg['name']}}">{{ coll_pkg['title'] }}</a></span>
+          <span>This dataset is part of the Collections:</span>
+          <ul class="collection-inline">
+          {% for tag in collection_tags %}
+          {% set coll_pkg = collection_packages_map[tag] %}
+            {% if coll_pkg %}
+            <li><a href="/collection/{{coll_pkg[0]['name']}}">{{ coll_pkg[0]['title'] }}</a></li>
+            {% else %}
+            <li><a href="{% url_for 'dataset.search', vocab_collection=tag %}">{{ tag }}</a></li>
+            {% endif %}
           {% endfor %}
-        </ul>
+          </ul>
         {% endif %}
 
       {% set lulc, biotable = h.natcap_collection_lulc_biotable(pkg) %}
@@ -48,6 +59,7 @@
       </div>
 
     {% elif pkg.type=='collection' and h.natcap_collection_has_datasets(pkg.collection[0]) %}
+    {% set collection_tag = pkg.collection[0] %}
       <div>
         <a href="{% url_for 'dataset.search', vocab_collection=collection_tag %}" role="button" type="button" class="btn btn-collection btn-lg btn-block">
           <i class="fa fa-layer-group" aria-hidden="true"></i>

--- a/src/ckanext-natcap/ckanext/natcap/templates/snippets/package_item.html
+++ b/src/ckanext-natcap/ckanext/natcap/templates/snippets/package_item.html
@@ -52,13 +52,16 @@
         {% endblock %}
         {% block collection %}
           {% if package.collection and package.type == 'dataset' %}
-            {% set collection_tag = package.collection[0] %}
-            {% set collection_packages = h.natcap_get_collection_name_url(collection_tag) %}
-            {% if not collection_packages %}
-              <span>This dataset is part of a Collection: <a href="{% url_for 'dataset.search', vocab_collection=collection_tag %}">{{ collection_tag }}</a></span>
-            {% elif collection_packages|length == 1 %}
-              <span>This dataset is part of a Collection: <a href="/collection/{{collection_packages[0]['name']}}" target="_blank">{{ collection_packages[0]['title'] }}</a></span>
-            {% endif %}
+            {% set collection_packages = h.natcap_get_collection_name_url(package.collection) %}
+            <p class="collection-inline">This dataset is part of the Collections:&nbsp;
+            {% for tag in package.collection %}
+              {% if collection_packages[tag] %}
+              <span><a href="/collection/{{collection_packages[tag][0]['name']}}" target="_blank">{{ tag }}&nbsp;</a></span>
+              {% else %}
+              <span><a href="{% url_for 'dataset.search', vocab_collection=tag %}">{{ tag }}&nbsp;</a></span>
+              {% endif %}
+            {% endfor %}
+            </p>
           {% endif %}
         {% endblock %}
         {% block notes %}


### PR DESCRIPTION
Previously, the templates (both the dataset list page and the dataset details page) were just displaying (and linking) the first collection tag on a dataset in the tile / sidebar. But I noticed @empavia had tagged the Historic Koppen-Geiger Climate Zone  datasets ([ex](https://data.naturalcapitalalliance.stanford.edu/dataset/sts-b1fa344a5515ec40d5c5f6edc2623a2dc76a99eeb229def201120a8d9e744c9d)) with both `KOPPEN-GEIGER CLIMATE ZONES` and `KOPPEN-GEIGER CLIMATE ZONES HISTORIC`. There's no reason this shouldn't be supported, and it's a feature I had wanted to add at some point anyway, so I figured I'd just go ahead and do it. 

Now, all collection tags should display in the sidebar, with links to either the associated Collection Package (if relevant) or a filtered search (if no associated Collection Package). See attached screenshots. (And ignore the fact that the tags here don't make sense; this was just for local testing!)

<img width="970" height="190" alt="Screenshot 2026-05-01 at 10 46 15 AM" src="https://github.com/user-attachments/assets/5289d0f7-f61e-45f3-827f-b6d8a6e4d716" />

<img width="346" height="355" alt="Screenshot 2026-05-01 at 10 46 24 AM" src="https://github.com/user-attachments/assets/bf5da803-02cd-4c9b-8e41-10a373ad13b3" />