### PR TITLE
Update titiler to add custom color ramp images

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,3 +1,15 @@
+
+# --- Build the legend JS source code and ship it with CKAN ---
+FROM node:26-alpine AS mapboxgl-legend-builder
+
+WORKDIR /tmp/mapbox-gl-legend
+RUN apk add git && \
+  git clone https://github.com/natcap/mapbox-gl-legend.git . && \
+  git checkout edecbdda495bf8a3654679c11bc0555ce90725cb && \
+  npm install && \
+  npm run build
+
+# --- Build CKAN but use the modified JS source for the legend ---
 FROM ckan/ckan-base:2.11.2
 
 ARG GITHUB_USER
@@ -63,6 +75,8 @@ RUN ckan config-tool $CKAN_INI --section app:main 'scheming.dataset_schemas=ckan
 
 # Copy custom initialization scripts
 COPY ./ckan/docker-entrypoint.d/* /docker-entrypoint.d/
+
+COPY --from=mapboxgl-legend-builder /tmp/mapbox-gl-legend/dist/cdn/mapbox-gl-legend.js /srv/app/src/ckanext-mappreview/ckanext/mappreview/assets/js/vendor/mapbox-gl-legend.js
 
 # Apply any patches needed to CKAN core or any of the built extensions (not the
 # runtime mounted ones)

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -5,7 +5,7 @@ FROM node:26-alpine AS mapboxgl-legend-builder
 WORKDIR /tmp/mapbox-gl-legend
 RUN apk add git && \
   git clone https://github.com/natcap/mapbox-gl-legend.git . && \
-  git checkout edecbdda495bf8a3654679c11bc0555ce90725cb && \
+  git checkout 924289931c9c502055900fc16d767313886ba9b0 && \
   npm install && \
   npm run build
 

--- a/src/ckanext-mappreview/ckanext/mappreview/assets/js/mappreview.js
+++ b/src/ckanext-mappreview/ckanext/mappreview/assets/js/mappreview.js
@@ -1,20 +1,14 @@
-
 ckan.module("mappreview", function ($, _) {
   "use strict";
   return {
     options: {
       config: {},
-        // config is pulled form attributes on the div.mappreview element.
+      // config is pulled form attributes on the div.mappreview element.
       globalConfig: {},
       debug: false,
     },
 
-    vectorColors: [
-      '#E04F39',
-      '#F9A44A',
-      '#FEC51D',
-      '#A57DAE',
-    ],
+    vectorColors: ["#E04F39", "#F9A44A", "#FEC51D", "#A57DAE"],
 
     /**
      * Linear scale pixel values to [0, 255] range
@@ -30,13 +24,15 @@ ckan.module("mappreview", function ($, _) {
     },
 
     _getRasterPoint: async function (layer, lngLat) {
-      const response = await fetch(`${this._getGlobalConfig().titiler_url}/cog/point/${lngLat.lng},${lngLat.lat}?url=${encodeURIComponent(layer.url)}`);
-      return (await response.json());
+      const response = await fetch(
+        `${this._getGlobalConfig().titiler_url}/cog/point/${lngLat.lng},${lngLat.lat}?url=${encodeURIComponent(layer.url)}`,
+      );
+      return await response.json();
     },
 
     _getRasterTilejsonUrl: function (layer) {
       const base = this._getGlobalConfig().titiler_url;
-      const endpoint = '/cog/WebMercatorQuad/tilejson.json';
+      const endpoint = "/cog/WebMercatorQuad/tilejson.json";
 
       const colors = [
         [75, 171, 57, 50], // #4BAB39
@@ -51,7 +47,11 @@ ckan.module("mappreview", function ($, _) {
 
       const percentiles = [2, 20, 40, 60, 80, 98];
       percentiles.forEach((percentile, i) => {
-        let colorIndex = this._getColorMapValue(layer.pixel_min_value, layer.pixel_max_value, layer[`pixel_percentile_${percentile}`]);
+        let colorIndex = this._getColorMapValue(
+          layer.pixel_min_value,
+          layer.pixel_max_value,
+          layer[`pixel_percentile_${percentile}`],
+        );
 
         // Color map must start with 0 and end with 255
         if (i === 0) colorIndex = 0;
@@ -64,15 +64,15 @@ ckan.module("mappreview", function ($, _) {
         tile_scale: 2,
         url: layer.url,
         bidx: 1,
-        format: 'webp',
+        format: "webp",
         rescale: `${layer.pixel_percentile_2},${layer.pixel_percentile_98}`,
         colormap: JSON.stringify(colormap),
-        colormap_type: 'linear',
+        colormap_type: "linear",
       };
 
       const paramsPrepared = Object.entries(params)
         .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
-        .join('&');
+        .join("&");
 
       return `${base}${endpoint}?${paramsPrepared}`;
     },
@@ -80,10 +80,10 @@ ckan.module("mappreview", function ($, _) {
     _getRasterLayer: function (layer) {
       return {
         id: layer.name,
-        type: 'raster',
+        type: "raster",
         source: layer.name,
         paint: {
-          'raster-opacity': ['interpolate', ['linear'], ['zoom'], 0, 0.75, 12, 1],
+          "raster-opacity": ["interpolate", ["linear"], ["zoom"], 0, 0.75, 12, 1],
         },
       };
     },
@@ -91,64 +91,61 @@ ckan.module("mappreview", function ($, _) {
     _getVectorLayers: function (layer, index) {
       const color = this.vectorColors[index % this.vectorColors.length];
 
-      if (layer.vector_type === 'Point') {
+      if (layer.vector_type === "Point") {
         return {
           id: layer.name,
-          type: 'circle',
+          type: "circle",
           source: layer.name,
           paint: {
-            'circle-radius': 5,
-            'circle-color': color,
+            "circle-radius": 5,
+            "circle-color": color,
           },
           center_lat_lon: layer.center_lat_lon,
         };
-      }
-      else if (layer.vector_type === 'Line' || layer.vector_type === "LineString") {
+      } else if (layer.vector_type === "Line" || layer.vector_type === "LineString") {
         return {
           id: layer.name,
-          type: 'line',
+          type: "line",
           source: layer.name,
           paint: {
-            'line-width': 5,
-            'line-color': color,
+            "line-width": 5,
+            "line-color": color,
           },
           center_lat_lon: layer.center_lat_lon,
         };
-      }
-      else if (layer.vector_type === 'Polygon') {
+      } else if (layer.vector_type === "Polygon") {
         return [
           {
             id: `${layer.name}-outline`,
-            type: 'line',
+            type: "line",
             source: layer.name,
             paint: {
-              'line-width': 2,
-              'line-color': color,
+              "line-width": 2,
+              "line-color": color,
             },
             center_lat_lon: layer.center_lat_lon,
           },
           {
             id: layer.name,
-            type: 'fill',
+            type: "fill",
             source: layer.name,
             paint: {
-              'fill-color': color,
-              'fill-opacity': 0.5
+              "fill-color": color,
+              "fill-opacity": 0.5,
             },
             center_lat_lon: layer.center_lat_lon,
-          }
+          },
         ];
-      }
-      else {
+      } else {
         console.error(`Layer type ${layer.vector_type} is not yet handled`);
       }
     },
     initialize: function () {
-      jQuery.proxyAll(this, '_getGlobalConfig');
-      jQuery.proxyAll(this, '_getRasterLayer');
-      jQuery.proxyAll(this, '_getRasterTilejsonUrl');
-      jQuery.proxyAll(this, '_getRasterPoint');
-      jQuery.proxyAll(this, '_getVectorLayers');
+      jQuery.proxyAll(this, "_getGlobalConfig");
+      jQuery.proxyAll(this, "_getRasterLayer");
+      jQuery.proxyAll(this, "_getRasterTilejsonUrl");
+      jQuery.proxyAll(this, "_getRasterPoint");
+      jQuery.proxyAll(this, "_getVectorLayers");
 
       const config = JSON.parse(this.options.config.replace(/'/g, '"'));
       const globalConfig = this._getGlobalConfig();
@@ -156,35 +153,34 @@ ckan.module("mappreview", function ($, _) {
 
       mapboxgl.accessToken = globalConfig.mapbox_api_key;
       const map = new mapboxgl.Map({
-        container: 'map',
+        container: "map",
         style: globalConfig.mapbox_style,
         bounds: config.map.bounds,
       });
-      map.addControl(new mapboxgl.FullscreenControl({}), 'top-left');
-      map.addControl(new mapboxgl.ScaleControl({maxWidth: 80, unit: 'metric'}), 'bottom-left');
+      map.addControl(new mapboxgl.FullscreenControl({}), "top-left");
+      map.addControl(new mapboxgl.ScaleControl({ maxWidth: 80, unit: "metric" }), "bottom-left");
 
-      const sources = config.layers.map(l => {
-        if (l.type === 'raster') {
+      const sources = config.layers.map((l) => {
+        if (l.type === "raster") {
           const url = this._getRasterTilejsonUrl(l);
           return {
             id: l.name,
-            type: 'raster',
+            type: "raster",
             url: url,
           };
-        }
-        else if (l.type === 'vector') {
-          if (l.url.endsWith('.geojson')) {
+        } else if (l.type === "vector") {
+          if (l.url.endsWith(".geojson")) {
             return {
               id: l.name,
-              type: 'geojson',
+              type: "geojson",
               data: l.url,
             };
-          } else if (l.url.endsWith('.mvt')) {
+          } else if (l.url.endsWith(".mvt")) {
             // The only authoritative way to get the correct layer name is to
             // request it from the MVT metadata.json file.
             return {
               id: l.name,
-              type: 'vector',
+              type: "vector",
               tiles: [`${l.url}/{z}/{x}/{y}.pbf`],
             };
           } else {
@@ -199,34 +195,31 @@ ckan.module("mappreview", function ($, _) {
 
       const layers = config.layers
         .map((l, i) => {
-          if (l.type === 'raster') {
+          if (l.type === "raster") {
             return this._getRasterLayer(l);
-          }
-          else if (l.type === 'vector') {
+          } else if (l.type === "vector") {
             var config = this._getVectorLayers(l, i);
-            if (l.url.endsWith('.mvt')) {
+            if (l.url.endsWith(".mvt")) {
               // If we're using a Mapbox Vector Tiles layer, we need to get the
               // layer name from its json metadata and add it to the mapbox gl
               // js layer configuration.
               fetch(`${l.url}/metadata.json`)
-                .then(response => response.json())
-                .then(data => {
-                  var layername = data['name'];
+                .then((response) => response.json())
+                .then((data) => {
+                  var layername = data["name"];
 
                   if (config.constructor === Object) {
-                    config['source-layer'] = layername;
+                    config["source-layer"] = layername;
                   } else if (config.constructor === Array) {
                     for (let i = 0; i < config.length; i++) {
-                      config[i]['source-layer'] = layername;
+                      config[i]["source-layer"] = layername;
                     }
                   } else {
-                    console.error(
-                      `Unexpected mapbox gl js layer config: ${l}`);
+                    console.error(`Unexpected mapbox gl js layer config: ${l}`);
                   }
                 })
-                .catch(error => {
-                  console.error(
-                    `Error fetching MVT metadata: ${l.url}/metadata.json`, error);
+                .catch((error) => {
+                  console.error(`Error fetching MVT metadata: ${l.url}/metadata.json`, error);
                 });
             }
             return config;
@@ -235,60 +228,66 @@ ckan.module("mappreview", function ($, _) {
             return null;
           }
         })
-        .filter(l => l !== null)
+        .filter((l) => l !== null)
         .flat()
         .toSorted((a, b) => {
-          const order = ['raster', 'fill', 'line', 'circle'];
+          const order = ["raster", "fill", "line", "circle"];
           return order.indexOf(a.type) - order.indexOf(b.type);
         });
 
-        let boundsArray = config.map.bounds;
-        function isGlobal(bounds) {
-          const [minLng, minLat, maxLng, maxLat] = bounds;
-          // loose restrictions on whats considered a global dataset
-          return (minLng <= -170 && maxLng >= 170 && minLat <= -50 && maxLat >= 50 );
-        }
-
-        function spinGlobe(userInteracting) {
-          if (!userInteracting) {
-              let distancePerSecond = 3;
-              const center = map.getCenter();
-              center.lng -= distancePerSecond;
-              // Smoothly animate the map over one second.
-              // When this animation is complete, it calls a 'moveend' event.
-              map.easeTo({ center, duration: 1000, easing: (n) => n });
-          }
+      let boundsArray = config.map.bounds;
+      function isGlobal(bounds) {
+        const [minLng, minLat, maxLng, maxLat] = bounds;
+        // loose restrictions on whats considered a global dataset
+        return minLng <= -170 && maxLng >= 170 && minLat <= -50 && maxLat >= 50;
       }
 
-        if (isGlobal(boundsArray)) {
-          map.setCenter([0,0]);
-          map.setMinZoom(1);
-          let userInteracting = false;
-          spinGlobe(userInteracting);
-          // Stop spinning if user moves mouse onto map
-          map.on('mousemove', () => {
-            userInteracting = true;
-          });
-          // When animation is complete, start spinning (if still no mouse move)
-          // Without this, rotation will stop
-          map.on('moveend', () => {
-            spinGlobe(userInteracting);
-          });
-        } else if (config.layers.length === 1 && config.layers[0].type === 'vector' && (
-          'center_lat_lon' in layers[0])) {
-          const centerLatLon =  layers[0].center_lat_lon;
-          if (centerLatLon) {
-            // mapbox uses long, lat format
-            map.setCenter([centerLatLon[1], centerLatLon[0]]);
-          }
-        } else { // bounds aren't global, and map doesn't just show 1 vector layer
-          map.fitBounds(boundsArray, { padding: 20, linear: true});
+      function spinGlobe(userInteracting) {
+        if (!userInteracting) {
+          let distancePerSecond = 3;
+          const center = map.getCenter();
+          center.lng -= distancePerSecond;
+          // Smoothly animate the map over one second.
+          // When this animation is complete, it calls a 'moveend' event.
+          map.easeTo({ center, duration: 1000, easing: (n) => n });
         }
+      }
 
-      map.on('load', () => {
+      if (isGlobal(boundsArray)) {
+        map.setCenter([0, 0]);
+        map.setMinZoom(1);
+        let userInteracting = false;
+        spinGlobe(userInteracting);
+        // Stop spinning if user moves mouse onto map
+        map.on("mousemove", () => {
+          userInteracting = true;
+        });
+        // When animation is complete, start spinning (if still no mouse move)
+        // Without this, rotation will stop
+        map.on("moveend", () => {
+          spinGlobe(userInteracting);
+        });
+      } else if (
+        config.layers.length === 1 &&
+        config.layers[0].type === "vector" &&
+        "center_lat_lon" in layers[0]
+      ) {
+        const centerLatLon = layers[0].center_lat_lon;
+        if (centerLatLon) {
+          // mapbox uses long, lat format
+          map.setCenter([centerLatLon[1], centerLatLon[0]]);
+        }
+      } else {
+        // bounds aren't global, and map doesn't just show 1 vector layer
+        map.fitBounds(boundsArray, { padding: 20, linear: true });
+      }
+
+      map.on("load", () => {
         sources.forEach((source) => {
           // Avoid warning about id
-          const cleanSource = Object.fromEntries(Object.entries(source).filter(([k, v]) => k !== 'id'));
+          const cleanSource = Object.fromEntries(
+            Object.entries(source).filter(([k, v]) => k !== "id"),
+          );
           map.addSource(source.id, cleanSource);
         });
 
@@ -296,14 +295,17 @@ ckan.module("mappreview", function ($, _) {
           map.addLayer(layer);
         });
 
-        const targets = Object.fromEntries(config.layers.map(l => [l.name, l.name]));
+        const targets = Object.fromEntries(config.layers.map((l) => [l.name, { label: l.name }]));
 
-        map.addControl(new MapboxLegendControl(targets, {
-          showDefault: true,
-          showCheckbox: true,
-          onlyRendered: false,
-          reverseOrder: true
-        }), 'top-right');
+        map.addControl(
+          new MapboxLegendControl(targets, {
+            showDefault: true,
+            showCheckbox: true,
+            onlyRendered: false,
+            reverseOrder: true,
+          }),
+          "top-right",
+        );
       });
 
       // Move event is triggered for a variety of interactions, so it's the
@@ -312,39 +314,42 @@ ckan.module("mappreview", function ($, _) {
       // CKAN doesn't want us to have multiple plugin assets interacting with
       // one another, so updating DOM attributes allows us to use the DOM as a
       // way to pass data between parts of the page.
-      for (const eventname of ['move', 'load']) {
+      for (const eventname of ["move", "load"]) {
         map.on(eventname, () => {
           const center = map.getCenter();
-          $('div.mappreview').attr({
+          $("div.mappreview").attr({
             "center-lat": center.lat,
             "center-lng": center.lng,
-            "zoom": map.getZoom(),
+            zoom: map.getZoom(),
           });
         });
       }
 
-      map.on('click', async (e) => {
+      map.on("click", async (e) => {
         let popupContent;
 
-        const vectorLayers = layers.filter(s => s.type !== 'raster');
+        const vectorLayers = layers.filter((s) => s.type !== "raster");
         if (vectorLayers.length > 0) {
-          const vectorFeature = map.queryRenderedFeatures(e.point, { layers: vectorLayers.map(l => l.id) })[0];
+          const vectorFeature = map.queryRenderedFeatures(e.point, {
+            layers: vectorLayers.map((l) => l.id),
+          })[0];
 
           if (vectorFeature) {
-            const rows = Object.entries(vectorFeature.properties)
-              .map(([key, value]) => `
+            const rows = Object.entries(vectorFeature.properties).map(
+              ([key, value]) => `
                 <div class="popup-key">${key}</div>
                 <div class="popup-value">${value}</div>
-              `);
+              `,
+            );
 
             popupContent = `<h3>${config.layers[0].name}</h3>
               <div class="popup-grid">
-                ${rows.join('')}
+                ${rows.join("")}
               </div>`;
           }
         }
 
-        if (!popupContent && (config.layers.length === 1 && config.layers[0].type === 'raster')) {
+        if (!popupContent && config.layers.length === 1 && config.layers[0].type === "raster") {
           const point = await this._getRasterPoint(config.layers[0], e.lngLat);
           if (!point) return;
 
@@ -356,14 +361,13 @@ ckan.module("mappreview", function ($, _) {
         }
 
         if (popupContent) {
-          const popup = new mapboxgl.Popup({ className: 'mappreview-mapboxgl-popup' })
+          const popup = new mapboxgl.Popup({ className: "mappreview-mapboxgl-popup" })
             .setLngLat(e.lngLat)
             .setMaxWidth("300px")
             .setHTML(popupContent)
             .addTo(map);
         }
       });
-
 
       /**********************************************************************
        * Bounding Box Clipping Logic
@@ -376,18 +380,16 @@ ckan.module("mappreview", function ($, _) {
 
       // These three attributes represent the application state needed.
       const bbox_geojson = {
-        type: 'FeatureCollection',
-        features: [
-          _createGeometryFromBbox(0, 0, 0, 0),
-        ],
+        type: "FeatureCollection",
+        features: [_createGeometryFromBbox(0, 0, 0, 0)],
       };
       var current_vertex = undefined;
       var box_move_origin = undefined;
-      const clip_button_id = 'natcapClipModeStart';
-      const legend_former_check_state = {}
-      const clipping_control_id = 'natcapClippingControl';
-      const clip_start_progress_modal_id = 'natcapClipStartProgressModal';
-      const clip_mode_cancel = 'natcapClipModeCancel';
+      const clip_button_id = "natcapClipModeStart";
+      const legend_former_check_state = {};
+      const clipping_control_id = "natcapClippingControl";
+      const clip_start_progress_modal_id = "natcapClipStartProgressModal";
+      const clip_mode_cancel = "natcapClipModeCancel";
 
       /* Translate the bounding box by some known diff
        *
@@ -395,294 +397,304 @@ ckan.module("mappreview", function ($, _) {
        * lng_diff (float): The amount in the y direction to shift the bbox
        */
       function _translateBbox(lat_diff, lng_diff) {
-          var coords = bbox_geojson.features[0].geometry.coordinates[0];
-          for (var i=0; i < 5; i++) {
-              coords[i][0] += lng_diff;
-              coords[i][1] += lat_diff;
-          }
+        var coords = bbox_geojson.features[0].geometry.coordinates[0];
+        for (var i = 0; i < 5; i++) {
+          coords[i][0] += lng_diff;
+          coords[i][1] += lat_diff;
+        }
       }
 
       function _createGeometryFromBbox(minx, maxx, miny, maxy) {
-          return {
-              type: 'Feature',
-              geometry: {
-                  type: "Polygon",
-                  coordinates: [[
-                      [minx, miny],
-                      [minx, maxy],
-                      [maxx, maxy],
-                      [maxx, miny],
-                      [minx, miny]
-                  ]],
-              }
-          }
+        return {
+          type: "Feature",
+          geometry: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [minx, miny],
+                [minx, maxy],
+                [maxx, maxy],
+                [maxx, miny],
+                [minx, miny],
+              ],
+            ],
+          },
+        };
       }
 
       function _updateBboxFromGT(minx, maxx, miny, maxy) {
-          console.log(minx, maxx, miny, maxy);
-          bbox_geojson.features[0] = _createGeometryFromBbox(minx, maxx, miny, maxy);
+        console.log(minx, maxx, miny, maxy);
+        bbox_geojson.features[0] = _createGeometryFromBbox(minx, maxx, miny, maxy);
       }
 
       function _vertices() {
-          var minx = bbox_geojson.features[0].geometry.coordinates[0][0][0];
-          var maxx = bbox_geojson.features[0].geometry.coordinates[0][2][0];
-          var miny = bbox_geojson.features[0].geometry.coordinates[0][0][1];
-          var maxy = bbox_geojson.features[0].geometry.coordinates[0][2][1];
-          return {
-              type: 'FeatureCollection',
-              features: [
-                  {type: 'Feature', properties: {loc: "sw"}, geometry: {type: "Point", coordinates: [minx, miny]}},
-                  {type: 'Feature', properties: {loc: "nw"}, geometry: {type: "Point", coordinates: [minx, maxy]}},
-                  {type: 'Feature', properties: {loc: "se"}, geometry: {type: "Point", coordinates: [maxx, miny]}},
-                  {type: 'Feature', properties: {loc: "ne"}, geometry: {type: "Point", coordinates: [maxx, maxy]}},
-              ],
-          }
+        var minx = bbox_geojson.features[0].geometry.coordinates[0][0][0];
+        var maxx = bbox_geojson.features[0].geometry.coordinates[0][2][0];
+        var miny = bbox_geojson.features[0].geometry.coordinates[0][0][1];
+        var maxy = bbox_geojson.features[0].geometry.coordinates[0][2][1];
+        return {
+          type: "FeatureCollection",
+          features: [
+            {
+              type: "Feature",
+              properties: { loc: "sw" },
+              geometry: { type: "Point", coordinates: [minx, miny] },
+            },
+            {
+              type: "Feature",
+              properties: { loc: "nw" },
+              geometry: { type: "Point", coordinates: [minx, maxy] },
+            },
+            {
+              type: "Feature",
+              properties: { loc: "se" },
+              geometry: { type: "Point", coordinates: [maxx, miny] },
+            },
+            {
+              type: "Feature",
+              properties: { loc: "ne" },
+              geometry: { type: "Point", coordinates: [maxx, maxy] },
+            },
+          ],
+        };
       }
 
       function _box() {
         var vertices = _vertices();
         return [
-          vertices.features[0].geometry.coordinates[0],  // west
-          vertices.features[0].geometry.coordinates[1],  // south
-          vertices.features[3].geometry.coordinates[0],  // east
-          vertices.features[3].geometry.coordinates[1],  // north
+          vertices.features[0].geometry.coordinates[0], // west
+          vertices.features[0].geometry.coordinates[1], // south
+          vertices.features[3].geometry.coordinates[0], // east
+          vertices.features[3].geometry.coordinates[1], // north
         ];
       }
 
       // Given a new vertex, update the geometry's relevant vertices
       function _updateVertex(loc, lat, lng) {
-          var coords = bbox_geojson.features[0].geometry.coordinates[0];
-          if (loc == "sw") {
-              // this location has 2 points to update, plus neighbors.
-              coords[0][0] = lng;
-              coords[0][1] = lat;
-              coords[4][0] = lng;
-              coords[4][1] = lat;
+        var coords = bbox_geojson.features[0].geometry.coordinates[0];
+        if (loc == "sw") {
+          // this location has 2 points to update, plus neighbors.
+          coords[0][0] = lng;
+          coords[0][1] = lat;
+          coords[4][0] = lng;
+          coords[4][1] = lat;
 
-              // update neighbors
-              coords[1][0] = lng;
-              coords[3][1] = lat;
+          // update neighbors
+          coords[1][0] = lng;
+          coords[3][1] = lat;
+        } else if (loc == "nw") {
+          coords[1][0] = lng;
+          coords[1][1] = lat;
 
-          } else if (loc == "nw") {
-              coords[1][0] = lng;
-              coords[1][1] = lat;
+          //update neighbors
+          coords[0][0] = lng;
+          coords[4][0] = lng;
+          coords[2][1] = lat;
+        } else if (loc == "ne") {
+          coords[2][0] = lng;
+          coords[2][1] = lat;
 
-              //update neighbors
-              coords[0][0] = lng;
-              coords[4][0] = lng;
-              coords[2][1] = lat;
+          // update neighbors
+          coords[1][1] = lat;
+          coords[3][0] = lng;
+        } else if (loc == "se") {
+          coords[3][0] = lng;
+          coords[3][1] = lat;
 
-          } else if (loc == "ne") {
-              coords[2][0] = lng;
-              coords[2][1] = lat;
-
-              // update neighbors
-              coords[1][1] = lat;
-              coords[3][0] = lng;
-
-          } else if (loc == "se") {
-              coords[3][0] = lng;
-              coords[3][1] = lat;
-
-              // update neighbors
-              coords[2][0] = lng;
-              coords[0][1] = lat;
-              coords[4][1] = lat;
-          }
+          // update neighbors
+          coords[2][0] = lng;
+          coords[0][1] = lat;
+          coords[4][1] = lat;
+        }
       }
 
       const canvas = map.getCanvasContainer();
 
       function onVertexMove(e) {
+        const coords = e.lngLat.toBounds();
 
-          const coords = e.lngLat.toBounds();
+        // set UI indicator for dragging
+        canvas.style.cursor = "grabbing";
 
-          // set UI indicator for dragging
-          canvas.style.cursor = 'grabbing';
+        // update the feature in the geojson object
+        // and call setData to the source layer geometry on it.
+        const bounds = e.lngLat.toBounds();
+        _updateVertex(current_vertex, bounds.getNorth(), bounds.getEast());
 
-          // update the feature in the geojson object
-          // and call setData to the source layer geometry on it.
-          const bounds = e.lngLat.toBounds();
-          _updateVertex(current_vertex, bounds.getNorth(), bounds.getEast());
-
-          map.getSource('bbox').setData(bbox_geojson);
-          map.getSource('vertices').setData(_vertices());
+        map.getSource("bbox").setData(bbox_geojson);
+        map.getSource("vertices").setData(_vertices());
       }
 
       function onVertexMouseUp(e) {
-          const coords = e.lngLat;
+        const coords = e.lngLat;
 
-          current_vertex = undefined;
+        current_vertex = undefined;
 
-          // unbind mouse/touch events
-          map.off('mousemove', onVertexMove);
-          map.off('touchmove', onVertexMove);
+        // unbind mouse/touch events
+        map.off("mousemove", onVertexMove);
+        map.off("touchmove", onVertexMove);
       }
 
       function onBoxMove(e) {
-          if (box_move_origin === undefined) {
-              return;
-          }
+        if (box_move_origin === undefined) {
+          return;
+        }
 
-          const coords = e.lngLat.toBounds();
-          var lat_diff = coords.getNorth() - box_move_origin.getNorth();
-          var lng_diff = coords.getWest() - box_move_origin.getWest();
+        const coords = e.lngLat.toBounds();
+        var lat_diff = coords.getNorth() - box_move_origin.getNorth();
+        var lng_diff = coords.getWest() - box_move_origin.getWest();
 
-          _translateBbox(lat_diff, lng_diff);
-          box_move_origin = coords;
-          map.getSource('bbox').setData(bbox_geojson);
-          map.getSource('vertices').setData(_vertices());
+        _translateBbox(lat_diff, lng_diff);
+        box_move_origin = coords;
+        map.getSource("bbox").setData(bbox_geojson);
+        map.getSource("vertices").setData(_vertices());
       }
 
       function onBoxMouseUp(e) {
-          box_move_origin = undefined;
+        box_move_origin = undefined;
 
-          // unbind mouse/touch events
-          map.off('mousemove', onVertexMove);
-          map.off('touchmove', onVertexMove);
+        // unbind mouse/touch events
+        map.off("mousemove", onVertexMove);
+        map.off("touchmove", onVertexMove);
       }
 
       function initBoundingBox() {
-          // on map startup, set bbox to 1/3 height and width of the viewport, centered at the centerpoint
-          // 1/3 was picked through trial and error.
-          var center = map.getCenter();
-          var viewport = map.getBounds();
-          _updateBboxFromGT(
-              center.lng - (center.lng - viewport.getWest())/3,  // minx
-              center.lng - (center.lng - viewport.getEast())/3,  // maxx
-              center.lat - (center.lat - viewport.getSouth())/3, // miny
-              center.lat - (center.lat - viewport.getNorth())/3  // maxy
-          )
-          if (map.getSource('bbox') === undefined) {
-            map.addSource('bbox', {type: 'geojson', data: bbox_geojson});
-          }
-          if (map.getSource('vertices') === undefined) {
-            map.addSource('vertices', {type: 'geojson', data: _vertices()});
-          }
-          map.addLayer({
-              id: 'bbox-fill',
-              type: 'fill',
-              source: 'bbox',
-              filter: ["all", ["==", "$type", "Polygon"]],
-              paint: {
-                "fill-color": "#FFFFFF",
-                "fill-outline-color": "#2E2D29",  // Process Black, from NatCap style guide
-                "fill-opacity": 0.5,
-              },
-          });
-          map.addLayer({
-              "id": "bbox-border",
-              "source": 'bbox',
-              "type": "line",
-              "filter": ["all", ["==", "$type", "Polygon"]],
-              "layout": {
-                  "line-cap": "round",
-                  "line-join": "round",
-              },
-              "paint": {
-                  "line-color": "#2E2D29",
-                  "line-dasharray": [0.2, 2],
-                  "line-width": 2,
-              },
-          });
-          map.addLayer({
-              "id": "vertices-dot",
-              "source": "vertices",
-              "type": "circle",
-              "filter": ["all",
-                  ["==", "$type", "Point"],
-              ],
-              "paint": {
-                  "circle-radius": 9,
-                  "circle-color": "#2E2D29",
-              },
-          });
-          map.addLayer({
-              "id": "vertices-border",
-              "source": "vertices",
-              "type": "circle",
-              "filter": ["all",
-                  ["==", "$type", "Point"],
-              ],
-              "paint": {
-                  "circle-radius": 7,
-                  "circle-color": "#FFF",
-              },
-          });
+        // on map startup, set bbox to 1/3 height and width of the viewport, centered at the centerpoint
+        // 1/3 was picked through trial and error.
+        var center = map.getCenter();
+        var viewport = map.getBounds();
+        _updateBboxFromGT(
+          center.lng - (center.lng - viewport.getWest()) / 3, // minx
+          center.lng - (center.lng - viewport.getEast()) / 3, // maxx
+          center.lat - (center.lat - viewport.getSouth()) / 3, // miny
+          center.lat - (center.lat - viewport.getNorth()) / 3, // maxy
+        );
+        if (map.getSource("bbox") === undefined) {
+          map.addSource("bbox", { type: "geojson", data: bbox_geojson });
+        }
+        if (map.getSource("vertices") === undefined) {
+          map.addSource("vertices", { type: "geojson", data: _vertices() });
+        }
+        map.addLayer({
+          id: "bbox-fill",
+          type: "fill",
+          source: "bbox",
+          filter: ["all", ["==", "$type", "Polygon"]],
+          paint: {
+            "fill-color": "#FFFFFF",
+            "fill-outline-color": "#2E2D29", // Process Black, from NatCap style guide
+            "fill-opacity": 0.5,
+          },
+        });
+        map.addLayer({
+          id: "bbox-border",
+          source: "bbox",
+          type: "line",
+          filter: ["all", ["==", "$type", "Polygon"]],
+          layout: {
+            "line-cap": "round",
+            "line-join": "round",
+          },
+          paint: {
+            "line-color": "#2E2D29",
+            "line-dasharray": [0.2, 2],
+            "line-width": 2,
+          },
+        });
+        map.addLayer({
+          id: "vertices-dot",
+          source: "vertices",
+          type: "circle",
+          filter: ["all", ["==", "$type", "Point"]],
+          paint: {
+            "circle-radius": 9,
+            "circle-color": "#2E2D29",
+          },
+        });
+        map.addLayer({
+          id: "vertices-border",
+          source: "vertices",
+          type: "circle",
+          filter: ["all", ["==", "$type", "Point"]],
+          paint: {
+            "circle-radius": 7,
+            "circle-color": "#FFF",
+          },
+        });
 
-          // Commenting out zoom because this will take a little thought to get
-          // this plus the bbox default size stuff working in a nice way.
-          //
-          // zoom in to the bounding box
-          //const bounds = new mapboxgl.LngLatBounds(map.getCenter(), map.getCenter());
-          //for (const coord of bbox_geojson.features[0].geometry.coordinates[0]) {
-          //  bounds.extend(coord);
-          //}
-          //map.fitBounds(bounds, {padding: 50, easing: true});
+        // Commenting out zoom because this will take a little thought to get
+        // this plus the bbox default size stuff working in a nice way.
+        //
+        // zoom in to the bounding box
+        //const bounds = new mapboxgl.LngLatBounds(map.getCenter(), map.getCenter());
+        //for (const coord of bbox_geojson.features[0].geometry.coordinates[0]) {
+        //  bounds.extend(coord);
+        //}
+        //map.fitBounds(bounds, {padding: 50, easing: true});
       }
 
       function hideBoundingBox() {
-          // Need to remove the layers before we remove the sources.
-          // Otherwise we get an error in the console.
-          for (const layer of ['bbox-fill', 'bbox-border', 'vertices-dot', 'vertices-border']) {
-              map.removeLayer(layer);
-          }
+        // Need to remove the layers before we remove the sources.
+        // Otherwise we get an error in the console.
+        for (const layer of ["bbox-fill", "bbox-border", "vertices-dot", "vertices-border"]) {
+          map.removeLayer(layer);
+        }
 
-          for (const source of ['bbox', 'vertices']) {
-              map.removeSource(source);
-          }
+        for (const source of ["bbox", "vertices"]) {
+          map.removeSource(source);
+        }
       }
 
       // the `load` event is fired after the first visually complete
       // rendering of the map has occurred.
-      map.on('load', () => {
-          map.on('mouseenter', 'vertices-dot', () => {
-              canvas.style.cursor = 'move';
-          });
+      map.on("load", () => {
+        map.on("mouseenter", "vertices-dot", () => {
+          canvas.style.cursor = "move";
+        });
 
-          map.on('mouseleave', 'vertices-dot', () => {
-              canvas.style.cursor = '';
-          });
+        map.on("mouseleave", "vertices-dot", () => {
+          canvas.style.cursor = "";
+        });
 
-          map.on('mousedown', 'vertices-dot', (e) => {
-              // prevent default map behavior
-              e.preventDefault();
+        map.on("mousedown", "vertices-dot", (e) => {
+          // prevent default map behavior
+          e.preventDefault();
 
-              // note which vertex we have clicked on
-              current_vertex = e.features[0].properties.loc;
-              canvas.style.cursor = 'grab';
+          // note which vertex we have clicked on
+          current_vertex = e.features[0].properties.loc;
+          canvas.style.cursor = "grab";
 
-              map.on('mousemove', onVertexMove);
-              map.once('mouseup', onVertexMouseUp);
-          });
+          map.on("mousemove", onVertexMove);
+          map.once("mouseup", onVertexMouseUp);
+        });
 
-          map.on('touchstart', 'vertices-dot', (e) => {
-              // prevent default map behavior
-              e.preventDefault();
+        map.on("touchstart", "vertices-dot", (e) => {
+          // prevent default map behavior
+          e.preventDefault();
 
-              // note which vertex we have clicked on
-              current_vertex = e.features[0].properties.loc;
-              canvas.style.cursor = 'grab';
+          // note which vertex we have clicked on
+          current_vertex = e.features[0].properties.loc;
+          canvas.style.cursor = "grab";
 
-              map.on('touchmove', onVertexMove);
-              map.once('touchend', onVertexMouseUp);
-          });
+          map.on("touchmove", onVertexMove);
+          map.once("touchend", onVertexMouseUp);
+        });
 
-          map.on('mouseenter', 'bbox-fill', (e) => {
-              canvas.style.cursor = 'move';
-          });
+        map.on("mouseenter", "bbox-fill", (e) => {
+          canvas.style.cursor = "move";
+        });
 
-          map.on('mouseleave', 'bbox-fill', (e) => {
-              canvas.style.cursor = '';
-          });
+        map.on("mouseleave", "bbox-fill", (e) => {
+          canvas.style.cursor = "";
+        });
 
-          map.on('mousedown', 'bbox-fill', (e) => {
-              // prevent default map behavior
-              e.preventDefault();
-              box_move_origin = e.lngLat.toBounds();
-              map.on('mousemove', onBoxMove);
-              map.once('mouseup', onBoxMouseUp);
-          });
+        map.on("mousedown", "bbox-fill", (e) => {
+          // prevent default map behavior
+          e.preventDefault();
+          box_move_origin = e.lngLat.toBounds();
+          map.on("mousemove", onBoxMove);
+          map.once("mouseup", onBoxMouseUp);
+        });
       });
 
       // clip the layer
@@ -697,11 +709,13 @@ ckan.module("mappreview", function ($, _) {
         }
 
         // hide the "Clip This Layer" button
-        document.getElementById(clip_button_id).classList.add('d-none');  // use classList.remove('d-none') to re-enable
+        document.getElementById(clip_button_id).classList.add("d-none"); // use classList.remove('d-none') to re-enable
 
         // Uncheck layers that aren't this one.
         // Track which layers are checked for when we exit clipping mode.
-        var legend_inputs = document.querySelectorAll('div.mapboxgl-legend-list table.legend-table input');
+        var legend_inputs = document.querySelectorAll(
+          "div.mapboxgl-legend-list table.legend-table input",
+        );
         for (const legend_input of legend_inputs) {
           legend_former_check_state[legend_input.name] = legend_input.checked;
           if (legend_input.name !== layer.name) {
@@ -715,35 +729,33 @@ ckan.module("mappreview", function ($, _) {
         initBoundingBox();
 
         // enable the progress modal trigger button
-        document.getElementById(clip_start_progress_modal_id).classList.remove('d-none');
-        document.getElementById(clip_mode_cancel).classList.remove('d-none');
+        document.getElementById(clip_start_progress_modal_id).classList.remove("d-none");
+        document.getElementById(clip_mode_cancel).classList.remove("d-none");
       }
 
       function natcapClipLayerCancel() {
-        document.getElementById(clip_button_id).classList.remove('d-none');
-        document.getElementById(clip_start_progress_modal_id).classList.add('d-none');
-        document.getElementById(clip_mode_cancel).classList.add('d-none');
+        document.getElementById(clip_button_id).classList.remove("d-none");
+        document.getElementById(clip_start_progress_modal_id).classList.add("d-none");
+        document.getElementById(clip_mode_cancel).classList.add("d-none");
         hideBoundingBox();
       }
 
-
       var selected_layer;
-      class ClippingControl{
+      class ClippingControl {
         onAdd(map) {
+          // config.layers attributes relevant to us
+          // name - filename (e.g. awc.tif)
+          // type - "raster"
+          // url - the clipping url
 
-            // config.layers attributes relevant to us
-            // name - filename (e.g. awc.tif)
-            // type - "raster"
-            // url - the clipping url
+          this._map = map;
+          this._container = document.createElement("div");
+          this._container.id = clipping_control_id;
+          this._container.className = "mapboxgl-ctrl";
+          this._container.textContent = "Hello, world";
 
-            this._map = map;
-            this._container = document.createElement('div');
-            this._container.id = clipping_control_id;
-            this._container.className = 'mapboxgl-ctrl';
-            this._container.textContent = 'Hello, world';
-
-            // append hidden buttons to the innerHTML, to be enabled when clipping mode starts.
-            var progress_modal_trigger_button = `
+          // append hidden buttons to the innerHTML, to be enabled when clipping mode starts.
+          var progress_modal_trigger_button = `
               <div class="btn-group" role="group">
                 <button class="btn btn-primary d-none"
                         type="button"
@@ -759,22 +771,22 @@ ckan.module("mappreview", function ($, _) {
                   Cancel
                   <i class="fa-solid fa-xmark"></i>
                 </button>
-              </div>`
+              </div>`;
 
-            var layers = [];
-            for (const layer of config.layers) {
-              layers.push(layer);
-            }
-            if (layers.length == 0) {
-              this._container.innerHTML = `
+          var layers = [];
+          for (const layer of config.layers) {
+            layers.push(layer);
+          }
+          if (layers.length == 0) {
+            this._container.innerHTML = `
                 <button type="button"
                         class="btn btn-outline-secondary"
                         disabled
                         title="No layers to clip.">
                   Clipping is disabled
                 </button>`;
-            } else if (layers.length == 1) {
-              this._container.innerHTML = `
+          } else if (layers.length == 1) {
+            this._container.innerHTML = `
                 <button type="button"
                         class="btn btn-secondary"
                         id='${clip_button_id}'>
@@ -782,26 +794,25 @@ ckan.module("mappreview", function ($, _) {
                   Clip this layer
                 </button>${progress_modal_trigger_button}`;
 
-              this._container.getElementsByTagName('button')[0].addEventListener('click', function() {
+            this._container
+              .getElementsByTagName("button")[0]
+              .addEventListener("click", function () {
                 // when the 'clip to this bounding box' button is selected, set an attribute of the button
-                document.getElementById(clip_button_id).setAttribute(
-                  'layer-name', layers[0].name);
-                document.getElementById(clip_button_id).setAttribute(
-                  'layer-url', layers[0].url);
-                document.getElementById(clip_button_id).setAttribute(
-                  'layer-type', layers[0].type);
+                document.getElementById(clip_button_id).setAttribute("layer-name", layers[0].name);
+                document.getElementById(clip_button_id).setAttribute("layer-url", layers[0].url);
+                document.getElementById(clip_button_id).setAttribute("layer-type", layers[0].type);
                 selected_layer = layers[0].name;
                 natcapClipLayer(layers[0].name);
 
                 // setting custom resolution only makes sense for rasters
                 if (layers[0].type == "vector") {
-                  document.getElementById('natcapClipPixelSize').style.display = 'none';
+                  document.getElementById("natcapClipPixelSize").style.display = "none";
                 }
               });
-            } else {
-              var clip_layer_string = "";
-              for (const clip_layer of layers) {
-                clip_layer_string += `
+          } else {
+            var clip_layer_string = "";
+            for (const clip_layer of layers) {
+              clip_layer_string += `
                   <li>
                     <a class="dropdown-item
                        href="#"
@@ -809,9 +820,9 @@ ckan.module("mappreview", function ($, _) {
                        layer-url=${clip_layer.url}>
                       ${clip_layer.name}
                     </a>
-                  </li>\n`
-              }
-              this._container.innerHTML = `
+                  </li>\n`;
+            }
+            this._container.innerHTML = `
                 <div class="dropup">
                   <button class='btn btn-secondary dropdown-toggle'
                           data-bs-toggle='dropdown'
@@ -826,220 +837,231 @@ ckan.module("mappreview", function ($, _) {
                 </div>
                 ${progress_modal_trigger_button}
               `;
-              for (const elem of this._container.getElementsByTagName('a')) {
-                elem.addEventListener('click', function() {
-                  // When clicked, note the selected layer in the modal.
-                  document.getElementById(clip_button_id).setAttribute(
-                    'layer-name', elem.getAttribute('layer-name'));
-                  document.getElementById(clip_button_id).setAttribute(
-                    'layer-url', elem.getAttribute('layer-url'));
-                  document.getElementById(clip_button_id).setAttribute(
-                    'layer-type', elem.getAttribute('layer-type'));
-                });
-              }
+            for (const elem of this._container.getElementsByTagName("a")) {
+              elem.addEventListener("click", function () {
+                // When clicked, note the selected layer in the modal.
+                document
+                  .getElementById(clip_button_id)
+                  .setAttribute("layer-name", elem.getAttribute("layer-name"));
+                document
+                  .getElementById(clip_button_id)
+                  .setAttribute("layer-url", elem.getAttribute("layer-url"));
+                document
+                  .getElementById(clip_button_id)
+                  .setAttribute("layer-type", elem.getAttribute("layer-type"));
+              });
             }
+          }
 
-            // add a handler for cancelling clipping mode.
-            // The button _should_ be in a known order, but we can just find
-            // all the possible buttons that might match and then just add the
-            // handler to the right one.
-            for (const btn of this._container.getElementsByTagName('button')) {
-              if (btn.id === clip_mode_cancel) {
-                btn.addEventListener('click', function() {
-                  natcapClipLayerCancel();
-                });
-              }
+          // add a handler for cancelling clipping mode.
+          // The button _should_ be in a known order, but we can just find
+          // all the possible buttons that might match and then just add the
+          // handler to the right one.
+          for (const btn of this._container.getElementsByTagName("button")) {
+            if (btn.id === clip_mode_cancel) {
+              btn.addEventListener("click", function () {
+                natcapClipLayerCancel();
+              });
             }
-            return this._container;
+          }
+          return this._container;
         }
 
         _toggleClippingOptions() {
-            if ($('#clipOptions').hasClass('show')) {
-                hideBoundingBox();
-            } else {
-                initBoundingBox();
-            }
-            $('#clipOptions').collapse('toggle');
+          if ($("#clipOptions").hasClass("show")) {
+            hideBoundingBox();
+          } else {
+            initBoundingBox();
+          }
+          $("#clipOptions").collapse("toggle");
         }
 
         onRemove() {
-            this._container.parentNode.removeChild(this._container);
-            this._map = undefined;
+          this._container.parentNode.removeChild(this._container);
+          this._map = undefined;
         }
       }
-      map.addControl(new ClippingControl(), 'bottom-right');
+      map.addControl(new ClippingControl(), "bottom-right");
 
       /**  Modal Controls
-        */
+       */
       function downloadComplete(download_url, filesize) {
-          document.getElementById('clipping-progress').classList.add('d-none');
-          document.getElementById('natcap-clip-cancel-button').classList.add('d-none');
-          document.getElementById('natcap-clip-done-button').classList.remove('d-none');
-          document.getElementById('download-size').innerText = filesize;
-          document.getElementById('natcapClipDownloadClippedLayer').classList.remove('d-none');
-          document.getElementById('natcapClipDownloadClippedLayer').setAttribute(
-            'onclick', `window.open('${download_url}')`);
-          document.getElementById('natcapClipInProgress').classList.add('d-none');
+        document.getElementById("clipping-progress").classList.add("d-none");
+        document.getElementById("natcap-clip-cancel-button").classList.add("d-none");
+        document.getElementById("natcap-clip-done-button").classList.remove("d-none");
+        document.getElementById("download-size").innerText = filesize;
+        document.getElementById("natcapClipDownloadClippedLayer").classList.remove("d-none");
+        document
+          .getElementById("natcapClipDownloadClippedLayer")
+          .setAttribute("onclick", `window.open('${download_url}')`);
+        document.getElementById("natcapClipInProgress").classList.add("d-none");
       }
 
       function submitForm() {
-          document.getElementById('clipping-progress').classList.remove('d-none');
-          document.getElementById('natcap-clip-cancel-button').classList.remove('d-none');
-          document.getElementById('natcap-clip-submit-button').classList.add('d-none');
-          document.getElementById('natcapClipInProgress').classList.remove('d-none');
-          document.getElementById('natcapClipInitOptions').classList.add('d-none');
+        document.getElementById("clipping-progress").classList.remove("d-none");
+        document.getElementById("natcap-clip-cancel-button").classList.remove("d-none");
+        document.getElementById("natcap-clip-submit-button").classList.add("d-none");
+        document.getElementById("natcapClipInProgress").classList.remove("d-none");
+        document.getElementById("natcapClipInitOptions").classList.add("d-none");
 
-          var target_file = document.getElementById(clip_button_id).getAttribute('layer-url');
-          var layer_type = document.getElementById(clip_button_id).getAttribute('layer-type');
-          console.log(`${layer_type}`);
-          var clipping_options = {
-            file_url: target_file,
-            target_bbox: _box(),
-            layer_type: layer_type,
-          }
+        var target_file = document.getElementById(clip_button_id).getAttribute("layer-url");
+        var layer_type = document.getElementById(clip_button_id).getAttribute("layer-type");
+        console.log(`${layer_type}`);
+        var clipping_options = {
+          file_url: target_file,
+          target_bbox: _box(),
+          layer_type: layer_type,
+        };
 
-          // are we overriding the EPSG code?  If not, don't include it in the clipping_options.
-          var epsg_override_checkbox = document.getElementById('natcapClipSettingOverrideEPSG');
-          if (epsg_override_checkbox.checked) {
-            var target_epsg = document.getElementById('natcapClipSettingEPSGCode').value;
-            clipping_options['target_epsg'] = target_epsg;
-          }
+        // are we overriding the EPSG code?  If not, don't include it in the clipping_options.
+        var epsg_override_checkbox = document.getElementById("natcapClipSettingOverrideEPSG");
+        if (epsg_override_checkbox.checked) {
+          var target_epsg = document.getElementById("natcapClipSettingEPSGCode").value;
+          clipping_options["target_epsg"] = target_epsg;
+        }
 
-          // are we overriding the pixel size?  If not, don't include it in the clipping options.
-          var pixelsize_override_checkbox = document.getElementById('natcapClipSettingOverridePixelSize');
-          if (pixelsize_override_checkbox.checked) {
-            var target_pixel_size = document.getElementById('natcapClipSettingPixelSize').value;
-            clipping_options['target_cellsize'] = [target_pixel_size, -target_pixel_size];
-          }
+        // are we overriding the pixel size?  If not, don't include it in the clipping options.
+        var pixelsize_override_checkbox = document.getElementById(
+          "natcapClipSettingOverridePixelSize",
+        );
+        if (pixelsize_override_checkbox.checked) {
+          var target_pixel_size = document.getElementById("natcapClipSettingPixelSize").value;
+          clipping_options["target_cellsize"] = [target_pixel_size, -target_pixel_size];
+        }
 
-          fetch(`${clipping_service_url}/clip`, {
-            method: "POST",
-            body: JSON.stringify(clipping_options),
-            headers: {
-              "Content-Type": "application/json",
-            },
-          }).then(response => {
+        fetch(`${clipping_service_url}/clip`, {
+          method: "POST",
+          body: JSON.stringify(clipping_options),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+          .then((response) => {
             if (response.ok) {
               return response.json();
             } else {
               console.error("Something went wrong while clipping");
               console.error(response);
             }
-          }).then(response_json => {
+          })
+          .then((response_json) => {
             downloadComplete(response_json.url, response_json.size);
           });
       }
 
       function resetState() {
-          document.getElementById('clipping-progress').classList.add('d-none');
-          document.getElementById('natcap-clip-cancel-button').classList.add('d-none');
-          document.getElementById('natcap-clip-done-button').classList.add('d-none');
-          document.getElementById('natcap-clip-submit-button').classList.remove('d-none');
-          document.getElementById('natcapClipInProgress').classList.add('d-none');
-          document.getElementById('natcapClipInitOptions').classList.remove('d-none');
-          document.getElementById('natcapClipDownloadClippedLayer').classList.add('d-none');
+        document.getElementById("clipping-progress").classList.add("d-none");
+        document.getElementById("natcap-clip-cancel-button").classList.add("d-none");
+        document.getElementById("natcap-clip-done-button").classList.add("d-none");
+        document.getElementById("natcap-clip-submit-button").classList.remove("d-none");
+        document.getElementById("natcapClipInProgress").classList.add("d-none");
+        document.getElementById("natcapClipInitOptions").classList.remove("d-none");
+        document.getElementById("natcapClipDownloadClippedLayer").classList.add("d-none");
       }
 
       function toggleOverrideField(check_input, text_field_id) {
-          var checked = document.getElementById(check_input).checked;
-          var epsg_field = document.getElementById(text_field_id);
+        var checked = document.getElementById(check_input).checked;
+        var epsg_field = document.getElementById(text_field_id);
 
-          if (epsg_field.classList.contains('d-none')) {
-              epsg_field.classList.remove('d-none');
-          }
+        if (epsg_field.classList.contains("d-none")) {
+          epsg_field.classList.remove("d-none");
+        }
 
-          if (!checked) {
-              epsg_field.classList.add('d-none');
-          }
+        if (!checked) {
+          epsg_field.classList.add("d-none");
+        }
       }
 
-      document.getElementById('natcap-clip-submit-button').addEventListener('click', submitForm);
-      document.getElementById('modal-close').addEventListener('click', resetState);
-      document.getElementById('natcap-clip-cancel-button').addEventListener('click', resetState);
-      document.getElementById('natcap-clip-done-button').addEventListener('click', resetState);
+      document.getElementById("natcap-clip-submit-button").addEventListener("click", submitForm);
+      document.getElementById("modal-close").addEventListener("click", resetState);
+      document.getElementById("natcap-clip-cancel-button").addEventListener("click", resetState);
+      document.getElementById("natcap-clip-done-button").addEventListener("click", resetState);
 
-      document.getElementById('natcapClipSettingOverrideEPSG').addEventListener(
-          'click', function() {
-              toggleOverrideField('natcapClipSettingOverrideEPSG', 'natcapClipSettingEPSGCode');
-              toggleOverrideField(
-                  'natcapClipSettingOverrideEPSG',
-                  'natcapClipSettingEPSGCodeLabel');
-      });
+      document
+        .getElementById("natcapClipSettingOverrideEPSG")
+        .addEventListener("click", function () {
+          toggleOverrideField("natcapClipSettingOverrideEPSG", "natcapClipSettingEPSGCode");
+          toggleOverrideField("natcapClipSettingOverrideEPSG", "natcapClipSettingEPSGCodeLabel");
+        });
 
-      document.getElementById('natcapClipSettingOverridePixelSize').addEventListener(
-          'click', function() {
-              toggleOverrideField('natcapClipSettingOverridePixelSize', 'natcapClipSettingPixelSize');
-              toggleOverrideField(
-                  'natcapClipSettingOverridePixelSize',
-                  'natcapClipSettingPixelSizeLabel');
-      });
+      document
+        .getElementById("natcapClipSettingOverridePixelSize")
+        .addEventListener("click", function () {
+          toggleOverrideField("natcapClipSettingOverridePixelSize", "natcapClipSettingPixelSize");
+          toggleOverrideField(
+            "natcapClipSettingOverridePixelSize",
+            "natcapClipSettingPixelSizeLabel",
+          );
+        });
 
-      document.getElementById('natcapClipEnableOverrides').addEventListener(
-          'click', function() {
-              toggleOverrideField(
-                  'natcapClipEnableOverrides',
-                  'natcapClipAdvancedOptions');
-              var warp = document.getElementById('natcapClipEnableOverrides').checked;
-              var submit_text;
-              if (warp) {
-                  submit_text = 'Warp/reproject the layer!'
-              } else {
-                  submit_text = "Clip this layer!"
-              }
-              document.getElementById('natcap-clip-submit-button').innerHTML = submit_text;
+      document.getElementById("natcapClipEnableOverrides").addEventListener("click", function () {
+        toggleOverrideField("natcapClipEnableOverrides", "natcapClipAdvancedOptions");
+        var warp = document.getElementById("natcapClipEnableOverrides").checked;
+        var submit_text;
+        if (warp) {
+          submit_text = "Warp/reproject the layer!";
+        } else {
+          submit_text = "Clip this layer!";
+        }
+        document.getElementById("natcap-clip-submit-button").innerHTML = submit_text;
       });
 
       function _setEPSGItems(epsg_code) {
         console.log(`Updating SRS info for ${epsg_code}`);
         fetch(`${clipping_service_url}/epsg_info?epsg_code=${epsg_code}`, {
           method: "GET",
-        }).then(epsg_response => {
-          if (epsg_response.ok) {
-            return epsg_response.json();
-          } else {
-            console.error(epsg_response);
-            throw new Error(`Response status: ${epsg_response.status}`);
-          }
-        }).then(epsg_json => {
-          if (epsg_json['status'] == 'success') {
-            document.getElementById('natcapClipSettingEPSGCodeLabel').textContent = epsg_json['epsg_name'];
-            document.getElementById('natcapClipSettingPixelSizeLabel').textContent = `Units: ${epsg_json['srs_units']}`;
-          } else {
-            console.error("Something went wrong getting EPSG info");
-            console.error(epsg_json);
-          }
-        });
+        })
+          .then((epsg_response) => {
+            if (epsg_response.ok) {
+              return epsg_response.json();
+            } else {
+              console.error(epsg_response);
+              throw new Error(`Response status: ${epsg_response.status}`);
+            }
+          })
+          .then((epsg_json) => {
+            if (epsg_json["status"] == "success") {
+              document.getElementById("natcapClipSettingEPSGCodeLabel").textContent =
+                epsg_json["epsg_name"];
+              document.getElementById("natcapClipSettingPixelSizeLabel").textContent =
+                `Units: ${epsg_json["srs_units"]}`;
+            } else {
+              console.error("Something went wrong getting EPSG info");
+              console.error(epsg_json);
+            }
+          });
       }
 
-
       function updateSRS() {
-        var epsg_input = document.getElementById('natcapClipSettingEPSGCode');
+        var epsg_input = document.getElementById("natcapClipSettingEPSGCode");
         if (epsg_input.value !== undefined) {
           _setEPSGItems(epsg_input.value);
         }
       }
-      document.getElementById('natcapClipSettingEPSGCode').addEventListener(
-        'change', function() {updateSRS()});
-
+      document.getElementById("natcapClipSettingEPSGCode").addEventListener("change", function () {
+        updateSRS();
+      });
 
       function updateSourceRasterInfo() {
-          const cog = document.getElementById(clip_button_id).getAttribute('layer-url');
-          console.log('updating source raster from cog ' + cog);
+        const cog = document.getElementById(clip_button_id).getAttribute("layer-url");
+        console.log("updating source raster from cog " + cog);
 
-          var epsg_input = document.getElementById('natcapClipSettingEPSGCode');
-          var cog_stats_url = `${clipping_service_url}/info?file_url=${encodeURIComponent(cog)}`;
-          fetch(cog_stats_url).then(response => {
+        var epsg_input = document.getElementById("natcapClipSettingEPSGCode");
+        var cog_stats_url = `${clipping_service_url}/info?file_url=${encodeURIComponent(cog)}`;
+        fetch(cog_stats_url)
+          .then((response) => {
             if (response.ok) {
               return response.json();
             } else {
               console.error(response);
             }
-          }).then(info_json => {
-            epsg_input.value = info_json['info']['stac']['proj:epsg'];
-            var geotransform = info_json['info']['geoTransform'];
+          })
+          .then((info_json) => {
+            epsg_input.value = info_json["info"]["stac"]["proj:epsg"];
+            var geotransform = info_json["info"]["geoTransform"];
             // Until someone says otherwise, let's assume square pixels
             // (in SRS units)
-            document.getElementById('natcapClipSettingPixelSize').value = geotransform[1];
+            document.getElementById("natcapClipSettingPixelSize").value = geotransform[1];
 
             // Update projection information like the friendly EPSG label and the human units.
             var epsg_code = epsg_input.value;
@@ -1047,10 +1069,9 @@ ckan.module("mappreview", function ($, _) {
           });
       }
 
-      document.getElementById('natcapClipEnableOverrides').addEventListener(
-          'click', function() {
-              updateSourceRasterInfo();
+      document.getElementById("natcapClipEnableOverrides").addEventListener("click", function () {
+        updateSourceRasterInfo();
       });
-    },  // end of initialize();
+    }, // end of initialize();
   };
 });

--- a/tileserver/Makefile
+++ b/tileserver/Makefile
@@ -1,0 +1,6 @@
+env313:
+	mamba create -y -p ./env313 python=3.13 pyproj gunicorn
+	./env313/bin/python -m pip install titiler==0.19.0 google-cloud-logging aiocache[redis] matplotlib pydantic-settings uvicorn fastapi==0.115.4
+
+dev: env313
+	PROJ_DATA=env313/share/proj ./env313/bin/python app/main.py

--- a/tileserver/Makefile
+++ b/tileserver/Makefile
@@ -1,6 +1,8 @@
+PORT := 8003
+
 env313:
 	mamba create -y -p ./env313 python=3.13 pyproj gunicorn
 	./env313/bin/python -m pip install titiler==0.19.0 google-cloud-logging aiocache[redis] matplotlib pydantic-settings uvicorn fastapi==0.115.4
 
 dev: env313
-	PROJ_DATA=env313/share/proj ./env313/bin/python app/main.py
+	PROJ_DATA=env313/share/proj PORT=$(PORT) ./env313/bin/python app/main.py

--- a/tileserver/app/dependencies.py
+++ b/tileserver/app/dependencies.py
@@ -32,7 +32,7 @@ class NatCapColorMapFactory(ColorMapFactory):
 
         # Add our own route.
         @self.router.get(
-            "/colorMaps/custom",
+            "/colorMapCustom",
             response_model=ColorMapType,
             summary="Retrieve a custom colorMap metadata or image.",
             operation_id="getCustomColorMap",

--- a/tileserver/app/dependencies.py
+++ b/tileserver/app/dependencies.py
@@ -8,6 +8,7 @@ import json
 from typing import Dict
 from typing import Literal
 from typing import Optional
+from typing import Sequence
 
 import matplotlib
 import numpy
@@ -15,7 +16,132 @@ from fastapi import HTTPException
 from fastapi import Query
 from rio_tiler.colormap import cmap as default_cmap
 from rio_tiler.colormap import parse_color
+from rio_tiler.models import ImageData
+from rio_tiler.types import ColorMapType
+from starlette.responses import Response
+from titiler.core.factory import ColorMapFactory
+from titiler.core.resources.enums import ImageType
 from typing_extensions import Annotated
+
+
+class NatCapColorMapFactory(ColorMapFactory):
+    def register_routes(self):
+        """Register colormap routes, derived from ColorMapFactory."""
+        # inherit all of the normal routes.
+        ColorMapFactory.register_routes(self)
+
+        # Add our own route.
+        @self.router.get(
+            "/colorMaps/custom",
+            response_model=ColorMapType,
+            summary="Retrieve a custom colorMap metadata or image.",
+            operation_id="getCustomColorMap",
+            responses={
+                200: {
+                    "content": {
+                        "application/json": {},
+                        "image/png": {},
+                        "image/jpeg": {},
+                        "image/jpg": {},
+                        "image/webp": {},
+                        "image/jp2": {},
+                        "image/tiff; application=geotiff": {},
+                        "application/x-binary": {},
+                    },
+                },
+            },
+        )
+        def colormap_custom(
+            colormap: Annotated[
+                str,
+                Query(description="JSON encoded custom Colormap"),
+            ],
+            colormap_type: Annotated[
+                Literal["explicit", "linear"],
+                Query(description="User input colormap type."),
+            ] = "explicit",
+            # image output options
+            format: Annotated[
+                Optional[ImageType],
+                Query(
+                    description="Return colorMap as Image.",
+                ),
+            ] = None,
+            orientation: Annotated[
+                Optional[Literal["vertical", "horizontal"]],
+                Query(
+                    description="Image Orientation.",
+                ),
+            ] = None,
+            height: Annotated[
+                Optional[int],
+                Query(
+                    description="Image Height (default to 20px for horizontal or 256px for vertical).",
+                ),
+            ] = None,
+            width: Annotated[
+                Optional[int],
+                Query(
+                    description="Image Width (default to 256px for horizontal or 20px for vertical).",
+                ),
+            ] = None,
+            ) -> Optional[Dict]:
+            """Custom user-defined colormap endpoint."""
+            cmap = ColorMapParams(colormap=colormap, colormap_type=colormap_type)
+            ###############################################################
+            # SEQUENCE CMAP
+            if isinstance(cmap, Sequence):
+                values = [minv for ((minv, _), _) in cmap]
+                arr = numpy.array([values] * 20)
+
+                if orientation == "vertical":
+                    height = height or 256 if len(values) < 256 else len(values)
+                else:
+                    width = width or 256 if len(values) < 256 else len(values)
+
+            ###############################################################
+            # DISCRETE CMAP
+            elif len(cmap) != 256 or max(cmap) >= 256 or min(cmap) < 0:
+                values = list(cmap)
+                arr = numpy.array([values] * 20)
+
+                if orientation == "vertical":
+                    height = height or 256 if len(values) < 256 else len(values)
+                else:
+                    width = width or 256 if len(values) < 256 else len(values)
+
+            ###############################################################
+            # LINEAR CMAP
+            else:
+                cmin, cmax = min(cmap), max(cmap)
+                arr = numpy.array(
+                    [
+                        numpy.round(numpy.linspace(cmin, cmax, num=256)).astype(
+                            numpy.uint8
+                        )
+                    ]
+                    * 20
+                )
+
+            if orientation == "vertical":
+                arr = arr.transpose([1, 0])
+
+            img = ImageData(arr)
+
+            width = width or img.width
+            height = height or img.height
+            if width != img.width or height != img.height:
+                img = img.resize(height, width)
+
+            return Response(
+                img.render(img_format=format.driver, colormap=cmap),
+                media_type=format.mediatype,
+            )
+
+            if isinstance(cmap, Sequence):
+                return [(k, numpy.array(v).tolist()) for (k, v) in cmap]
+            else:
+                return {k: numpy.array(v).tolist() for k, v in cmap.items()}
 
 
 def ColorMapParams(

--- a/tileserver/app/main.py
+++ b/tileserver/app/main.py
@@ -7,46 +7,44 @@ This file (minus modifications) was originally licensed under the MIT license.
 """
 
 import logging
-import sys
-import re
 import os
+import re
+import sys
 
+import dependencies
+import google.cloud.logging
 import jinja2
-from fastapi import Depends, FastAPI, HTTPException, Security
+from fastapi import Depends
+from fastapi import FastAPI
+from fastapi import HTTPException
+from fastapi import Security
 from fastapi.security.api_key import APIKeyQuery
-from rio_tiler.io import Reader, STACReader
+from rio_tiler.io import Reader
+from rio_tiler.io import STACReader
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import HTMLResponse
 from starlette.templating import Jinja2Templates
 from starlette_cramjam.middleware import CompressionMiddleware
-
 from titiler.application import __version__ as titiler_version
 from titiler.application.settings import ApiSettings
-from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
-from titiler.core.factory import (
-    AlgorithmFactory,
-    ColorMapFactory,
-    MultiBaseTilerFactory,
-    TMSFactory,
-)
-from titiler.core.middleware import (
-    CacheControlMiddleware,
-    LoggerMiddleware,
-    LowerCaseQueryStringMiddleware,
-    TotalTimeMiddleware,
-)
-from titiler.extensions import (
-    cogValidateExtension,
-    cogViewerExtension,
-    stacExtension,
-    stacViewerExtension,
-)
+from titiler.core.errors import add_exception_handlers
+from titiler.core.errors import DEFAULT_STATUS_CODES
+from titiler.core.factory import AlgorithmFactory
+from titiler.core.factory import MultiBaseTilerFactory
+from titiler.core.factory import TMSFactory
+from titiler.core.middleware import CacheControlMiddleware
+from titiler.core.middleware import LoggerMiddleware
+from titiler.core.middleware import LowerCaseQueryStringMiddleware
+from titiler.core.middleware import TotalTimeMiddleware
+from titiler.extensions import cogValidateExtension
+from titiler.extensions import cogViewerExtension
+from titiler.extensions import stacExtension
+from titiler.extensions import stacViewerExtension
 from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 from titiler.mosaic.factory import MosaicTilerFactory
-import google.cloud.logging
 
-from cache import setup_cache
+#from cache import setup_cache
 
 #logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
@@ -127,10 +125,11 @@ if not api_settings.disable_cog:
     if os.path.exists('/app'):
         sys.path.append('/app')
 
-    # Setup Cache
-    app.add_event_handler('startup', setup_cache)
+    ## Setup Cache
+    #app.add_event_handler('startup', setup_cache)
 
-    from dependencies import ColorMapParams, DatasetPathParams
+    from dependencies import ColorMapParams
+    from dependencies import DatasetPathParams
     from routes import TilerFactory
 
     cog = TilerFactory(
@@ -197,7 +196,7 @@ app.include_router(
 
 ###############################################################################
 # Colormaps endpoints
-cmaps = ColorMapFactory()
+cmaps = dependencies.NatCapColorMapFactory()
 app.include_router(
     cmaps.router,
     tags=["ColorMaps"],

--- a/tileserver/app/routes.py
+++ b/tileserver/app/routes.py
@@ -1,21 +1,30 @@
-from typing import Callable, Dict, Type, Literal, List, Tuple, Optional
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Literal
+from typing import Optional
+from typing import Tuple
+from typing import Type
 from urllib.parse import urlencode
 
+import rasterio
 from attrs import define
-from titiler.core.factory import TilerFactory as TiTilerFactory
-from titiler.core.factory import img_endpoint_params
-from titiler.core.resources.enums import ImageType
-from titiler.core.models.mapbox import TileJSON
-from titiler.core.utils import render_image
-from rio_tiler.io import BaseReader, Reader
-from fastapi import Depends, Path, Query
+from fastapi import Depends
+from fastapi import Path
+from fastapi import Query
 from pydantic import Field
+from rio_tiler.io import BaseReader
+from rio_tiler.io import Reader
 from starlette.requests import Request
 from starlette.responses import Response
-import rasterio
+from titiler.core.factory import img_endpoint_params
+from titiler.core.factory import TilerFactory as TiTilerFactory
+from titiler.core.models.mapbox import TileJSON
+from titiler.core.resources.enums import ImageType
+from titiler.core.utils import render_image
 from typing_extensions import Annotated
 
-from cache import cached
+#from cache import cached
 
 @define(kw_only=True)
 class TilerFactory(TiTilerFactory):
@@ -116,7 +125,7 @@ class TilerFactory(TiTilerFactory):
             )
 
             return Response(content, media_type=media_type)
-        
+
         @self.router.get(
             "/{tileMatrixSetId}/tilejson.json",
             response_model=TileJSON,
@@ -204,7 +213,7 @@ class TilerFactory(TiTilerFactory):
                         "maxzoom": maxzoom if maxzoom is not None else src_dst.maxzoom,
                         "tiles": [tiles_url],
                     }
-                
+
         # Register all other routes.  These are copied from the original TilerFactory class.
         self.bounds()
         self.info()  # Used by our CKAN instance


### PR DESCRIPTION
I've separated out the titiler modifications needed for custom color ramp images so that we can deploy these changes separately and develop against them outside of localhost.

This PR adds a new endpoint to titiler that will generate custom PNG (or other format) images of a target width/height from the same kind of JSON configuration that we use for our existing tiles.